### PR TITLE
Change from string to interface{}

### DIFF
--- a/core/search.go
+++ b/core/search.go
@@ -9,7 +9,7 @@ import (
 
 // Performs a very basic search on an index via the request URI API.
 // http://www.elasticsearch.org/guide/reference/api/search/uri-request.html
-func Search(pretty bool, index string, _type string, query string) (SearchResult, error) {
+func Search(pretty bool, index string, _type string, query interface{}) (SearchResult, error) {
 	log.Printf("query is: %s", query)
 	var url string
 	var retval SearchResult


### PR DESCRIPTION
I'm building my own complex query objects as map[string]interface{} and need a way to run them.  If I serialize it first and pass in the string, it gets Marshal'd again by SetBodyJson.
