### PR TITLE
Byte types return, Logging cleanup

### DIFF
--- a/api/baseRequest.go
+++ b/api/baseRequest.go
@@ -7,9 +7,9 @@ import (
 	"log"
 )
 
-func DoCommand(method string, url string, data interface{}) (string, error) {
+func DoCommand(method string, url string, data interface{}) ([]byte, error) {
 	var response map[string]interface{}
-	var body string
+	var body []byte
 	req, err := ElasticSearchRequest(method, url)
 	if err != nil {
 		return body, err
@@ -43,7 +43,7 @@ func DoCommand(method string, url string, data interface{}) (string, error) {
 // returning nothing
 func Exists(pretty bool, index string, _type string, id string) (BaseResponse, error) {
 	var response map[string]interface{}
-	var body string
+	var body []byte
 	var url string
 	var retval BaseResponse
 
@@ -59,14 +59,15 @@ func Exists(pretty bool, index string, _type string, id string) (BaseResponse, e
 	body, err = req.Do(&response)
 	if error, ok := response["error"]; ok {
 		status, _ := response["status"]
-		log.Fatalf("Error: %v (%v)\n", error, status)
+		log.Println("Error: %v (%v)\n", error, status)
+
 	} else {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
-			log.Fatal(jsonErr)
+			log.Println(jsonErr)
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(string(body))
 	return retval, err
 }

--- a/api/request.go
+++ b/api/request.go
@@ -81,10 +81,10 @@ func (r *Request) SetBody(body io.Reader) {
 	}
 }
 
-func (r *Request) Do(v interface{}) (string, error) {
+func (r *Request) Do(v interface{}) ([]byte, error) {
 	res, err := http.DefaultClient.Do((*http.Request)(r))
 	if err != nil {
-		return "", err
+		return 0, nil, err
 	}
 
 	defer res.Body.Close()
@@ -93,8 +93,8 @@ func (r *Request) Do(v interface{}) (string, error) {
 	if v != nil {
 		jsonErr := json.Unmarshal(bodyBytes, v)
 		if jsonErr != nil {
-			return "", err
+			return nil, err
 		}
 	}
-	return string(bodyBytes), err
+	return bodyBytes, nil
 }

--- a/client.go
+++ b/client.go
@@ -17,17 +17,26 @@ package main
 
 import (
 	"encoding/json"
+	"flag"
+	"github.com/mattbaird/elastigo/api"
 	"github.com/mattbaird/elastigo/cluster"
 	"github.com/mattbaird/elastigo/core"
 	"github.com/mattbaird/elastigo/indices"
 	"log"
 )
 
+var (
+	eshost *string = flag.String("host", "localhost", "Elasticsearch Server Host Address")
+)
+
 // for testing
 func main() {
+	flag.Parse()
+	log.SetFlags(log.Ltime | log.Lshortfile)
+	api.Domain = *eshost
 	response, _ := core.Index(true, "twitter", "tweet", "1", NewTweet("kimchy", "Search is cool"))
 	indices.Flush()
-	log.Printf("Index OK: %b", response.Ok)
+	log.Printf("Index OK: %v", response.Ok)
 	searchresponse, err := core.Search(true, "twitter", "tweet", "{\"query\" : {\"term\" : { \"user\" : \"kimchy\" }}}", "")
 	if err != nil {
 		log.Println("error during search:" + err.Error())
@@ -38,19 +47,19 @@ func main() {
 	json.Unmarshal(searchresponse.Hits.Hits[0].Source, t)
 	log.Printf("Search Found: %s", t)
 	response, _ = core.Get(true, "twitter", "tweet", "1")
-	log.Printf("Get: %s", response.Exists)
+	log.Printf("Get: %v", response.Exists)
 	response, _ = core.Exists(true, "twitter", "tweet", "1")
-	log.Printf("Exists: %s", response.Exists)
+	log.Printf("Exists: %v", response.Exists)
 	indices.Flush()
 	countResponse, _ := core.Count(true, "twitter", "tweet")
-	log.Printf("Count: %s", countResponse.Count)
+	log.Printf("Count: %v", countResponse.Count)
 	response, _ = core.Delete(true, "twitter", "tweet", "1", -1, "")
-	log.Printf("Delete OK: %b", response.Ok)
+	log.Printf("Delete OK: %v", response.Ok)
 	response, _ = core.Get(true, "twitter", "tweet", "1")
-	log.Printf("Get: %s", response.Exists)
+	log.Printf("Get: %v", response.Exists)
 
 	healthResponse, _ := cluster.Health(true)
-	log.Printf("Health: %s", healthResponse.Status)
+	log.Printf("Health: %v", healthResponse.Status)
 
 	cluster.State("transient", "discovery.zen.minimum_master_nodes", 2)
 

--- a/cluster/clusterReroute.go
+++ b/cluster/clusterReroute.go
@@ -26,7 +26,7 @@ func Reroute(pretty bool, dryRun bool, commands Commands) (ClusterHealthResponse
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/cluster/health.go
+++ b/cluster/health.go
@@ -26,12 +26,12 @@ func Health(pretty bool, indices ...string) (ClusterHealthResponse, error) {
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(body)
 	return retval, err
 }
 

--- a/core/count.go
+++ b/core/count.go
@@ -28,11 +28,11 @@ func Count(pretty bool, index string, _type string) (CountResponse, error) {
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(body)
 	return retval, err
 }

--- a/core/delete.go
+++ b/core/delete.go
@@ -19,11 +19,11 @@ func Delete(pretty bool, index string, _type string, id string, version int, rou
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(body)
 	return retval, err
 }

--- a/core/deleteByQuery.go
+++ b/core/deleteByQuery.go
@@ -25,7 +25,7 @@ func DeleteByQuery(pretty bool, indices []string, types []string, query interfac
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/core/explain.go
+++ b/core/explain.go
@@ -24,7 +24,7 @@ func Explain(pretty bool, index string, _type string, id string, query string) (
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/core/get.go
+++ b/core/get.go
@@ -25,12 +25,12 @@ func Get(pretty bool, index string, _type string, id string) (api.BaseResponse, 
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(body)
 	return retval, err
 }
 
@@ -51,11 +51,11 @@ func Exists(pretty bool, index string, _type string, id string) (api.BaseRespons
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(body)
 	return retval, err
 }

--- a/core/index.go
+++ b/core/index.go
@@ -25,11 +25,11 @@ func Index(pretty bool, index string, _type string, id string, data interface{})
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(body)
 	return retval, err
 }

--- a/core/mget.go
+++ b/core/mget.go
@@ -27,7 +27,7 @@ func MGet(pretty bool, index string, _type string, mgetRequest MGetRequestContai
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/core/moreLikeThis.go
+++ b/core/moreLikeThis.go
@@ -18,7 +18,7 @@ func MoreLikeThis(pretty bool, index string, _type string, id string, query More
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/core/percolate.go
+++ b/core/percolate.go
@@ -22,7 +22,7 @@ func RegisterPercolate(pretty bool, index string, name string, query api.Query) 
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
@@ -41,7 +41,7 @@ func Percolate(pretty bool, index string, _type string, name string, doc string)
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/core/search.go
+++ b/core/search.go
@@ -22,7 +22,7 @@ func Search(pretty bool, index string, _type string, query interface{}, scroll s
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
@@ -42,7 +42,7 @@ func Scroll(pretty bool, scroll_id string, scroll string) (SearchResult, error) 
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/core/update.go
+++ b/core/update.go
@@ -26,7 +26,7 @@ func Update(pretty bool, index string, _type string, id string) (api.BaseRespons
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/core/validate.go
+++ b/core/validate.go
@@ -22,7 +22,7 @@ func Validate(pretty bool, index string, _type string, query string, explain boo
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/indices/flush.go
+++ b/indices/flush.go
@@ -26,11 +26,11 @@ func Flush(index ...string) (api.BaseResponse, error) {
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}
 	}
-	fmt.Println(body)
+	//fmt.Println(body)
 	return retval, err
 }

--- a/indices/refresh.go
+++ b/indices/refresh.go
@@ -26,7 +26,7 @@ func Refresh(indices ...string) (api.BaseResponse, error) {
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}

--- a/indices/status.go
+++ b/indices/status.go
@@ -11,7 +11,6 @@ import (
 // http://www.elasticsearch.org/guide/reference/api/admin-indices-status.html
 func Status(pretty bool, indices ...string) (api.BaseResponse, error) {
 	var retval api.BaseResponse
-	var body string
 	var url string
 	if len(indices) > 0 {
 		url = fmt.Sprintf("/%s/_status?%s", strings.Join(indices, ","), api.Pretty(pretty))
@@ -25,7 +24,7 @@ func Status(pretty bool, indices ...string) (api.BaseResponse, error) {
 	}
 	if err == nil {
 		// marshall into json
-		jsonErr := json.Unmarshal([]byte(body), &retval)
+		jsonErr := json.Unmarshal(body, &retval)
 		if jsonErr != nil {
 			return retval, jsonErr
 		}


### PR DESCRIPTION
Convert string return to []byte, prevents []byte->string->[]byte
change log.Fatal() -> log.Println(), (log.Fatal does os.exit, which is a bit aggressive)
remove extra prints
cleanup logging on client.go test
