### PR TITLE
Added automatic id generation support for bulk

### DIFF
--- a/core/bulk.go
+++ b/core/bulk.go
@@ -318,8 +318,10 @@ func WriteBulkBytes(op string, index string, _type string, id, ttl string, date 
 	buf.WriteString(index)
 	buf.WriteString(`","_type":"`)
 	buf.WriteString(_type)
-	buf.WriteString(`","_id":"`)
-	buf.WriteString(id)
+	if len(id) > 0 {
+		buf.WriteString(`","_id":"`)
+		buf.WriteString(id)
+	}
 
 	if op == "update"  {
 		buf.WriteString(`","retry_on_conflict":"3`)


### PR DESCRIPTION
Without this commit you can't omit id when using bulk.
You get a document in the index with an _id field with the value "".

This commit fixed this and really omits the _id field when empty.
