### PR TITLE
DoResponse method should return correct errors.

### DIFF
--- a/api/request.go
+++ b/api/request.go
@@ -96,11 +96,15 @@ func (r *Request) DoResponse(v interface{}) (*http.Response, []byte, error) {
 
 	defer res.Body.Close()
 	bodyBytes, err := ioutil.ReadAll(res.Body)
-
+	
+	if err != nil {
+		return nil, nil, err
+	}
+	
 	if res.StatusCode > 304 && v != nil {
 		jsonErr := json.Unmarshal(bodyBytes, v)
 		if jsonErr != nil {
-			return nil, nil, err
+			return nil, nil, jsonErr
 		}
 	}
 	return res, bodyBytes, err


### PR DESCRIPTION
When json.Unmarshal fails in the DoResponse method it should returns the associated error. Currently it returns the error generated from ioutil.ReadAll with isn't directly related. I think that the DoResponse method should return an error if the ioutil.ReadAll fails and not attempt the json.Unmarshal. These unreported cause the error propagation to fail which results nil pointer issues later.

Please let me know if there is anything additional I need to do to get this merged into the main branch.
