### PR TITLE
Correct indexor -> indexer in code and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ status updates
 ========================
 
 * *2013-9-27* Fleshing out cluster and indices APIs, updated vagrant image to 0.90.3
-* *2013-7-10* Improvements/changes to bulk indexor (includes breaking changes to support TTL),
+* *2013-7-10* Improvements/changes to bulk indexer (includes breaking changes to support TTL),
          Search dsl supports And/Or/Not
     * *SearchDsl* should still be considered beta at this
          point, there will be minor breaking changes as more of the
@@ -133,18 +133,18 @@ example:
     api.Domain = "localhost"
     // api.Port = "9300"
 
-    indexor := core.NewBulkIndexorErrors(10, 60)
+    indexer := core.NewBulkIndexerErrors(10, 60)
     done := make(chan bool)
-    indexor.Run(done)
+    indexer.Run(done)
 
     go func() {
-      for errBuf := range indexor.ErrorChannel {
+      for errBuf := range indexer.ErrorChannel {
         // just blissfully print errors forever
         fmt.Println(errBuf.Err)
       }
     }()
     for i := 0; i < 20; i++ {
-      indexor.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
+      indexer.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
     }
     done <- true
 

--- a/core/example_test.go
+++ b/core/example_test.go
@@ -21,39 +21,39 @@ import (
 )
 
 // The simplest usage of background bulk indexing
-func ExampleBulkIndexor_simple() {
-	indexor := core.NewBulkIndexorErrors(10, 60)
+func ExampleBulkIndexer_simple() {
+	indexer := core.NewBulkIndexerErrors(10, 60)
 	done := make(chan bool)
-	indexor.Run(done)
+	indexer.Run(done)
 
-	indexor.Index("twitter", "user", "1", "", nil, `{"name":"bob"}`)
+	indexer.Index("twitter", "user", "1", "", nil, `{"name":"bob"}`)
 
 	<-done // wait forever
 }
 
 // The simplest usage of background bulk indexing with error channel
-func ExampleBulkIndexor_errorchannel() {
-	indexor := core.NewBulkIndexorErrors(10, 60)
+func ExampleBulkIndexer_errorchannel() {
+	indexer := core.NewBulkIndexerErrors(10, 60)
 	done := make(chan bool)
-	indexor.Run(done)
+	indexer.Run(done)
 
 	go func() {
-		for errBuf := range indexor.ErrorChannel {
+		for errBuf := range indexer.ErrorChannel {
 			// just blissfully print errors forever
 			fmt.Println(errBuf.Err)
 		}
 	}()
 	for i := 0; i < 20; i++ {
-		indexor.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
+		indexer.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
 	}
 	done <- true
 }
 
 // The simplest usage of background bulk indexing with error channel
-func ExampleBulkIndexor_errorsmarter() {
-	indexor := core.NewBulkIndexorErrors(10, 60)
+func ExampleBulkIndexer_errorsmarter() {
+	indexer := core.NewBulkIndexerErrors(10, 60)
 	done := make(chan bool)
-	indexor.Run(done)
+	indexer.Run(done)
 
 	errorCt := 0 // use sync.atomic or something if you need
 	timer := time.NewTicker(time.Minute * 3)
@@ -71,23 +71,23 @@ func ExampleBulkIndexor_errorsmarter() {
 	}()
 
 	go func() {
-		for errBuf := range indexor.ErrorChannel {
+		for errBuf := range indexer.ErrorChannel {
 			errorCt++
 			fmt.Println(errBuf.Err)
 			// log to disk?  db?   ????  Panic
 		}
 	}()
 	for i := 0; i < 20; i++ {
-		indexor.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
+		indexer.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
 	}
 	done <- true // send shutdown signal
 }
 
 // The inspecting the response
-func ExampleBulkIndexor_responses() {
-	indexor := core.NewBulkIndexor(10)
+func ExampleBulkIndexer_responses() {
+	indexer := core.NewBulkIndexer(10)
 	// Create a custom Sendor Func, to allow inspection of response/error
-	indexor.BulkSendor = func(buf *bytes.Buffer) error {
+	indexer.BulkSendor = func(buf *bytes.Buffer) error {
 		// @buf is the buffer of docs about to be written
 		respJson, err := api.DoCommand("POST", "/_bulk", buf)
 		if err != nil {
@@ -97,10 +97,10 @@ func ExampleBulkIndexor_responses() {
 		return err
 	}
 	done := make(chan bool)
-	indexor.Run(done)
+	indexer.Run(done)
 
 	for i := 0; i < 20; i++ {
-		indexor.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
+		indexer.Index("twitter", "user", strconv.Itoa(i), "", nil, `{"name":"bob"}`)
 	}
 	done <- true // send shutdown signal
 }

--- a/search/test_test.go
+++ b/search/test_test.go
@@ -44,7 +44,7 @@ func init() {
 	}
 }
 
-func InitTests(startIndexor bool) {
+func InitTests(startIndexer bool) {
 	if !hasStartedTesting {
 		flag.Parse()
 		hasStartedTesting = true


### PR DESCRIPTION
This is a breaking change, but it seems better to do it now than later.
As far as I know Go doesn't have a nice way to alias everything
involved, but let me know if you'd like me to do so anyway.
