### PR TITLE
Exists shouldn't return error.

### DIFF
--- a/core/get.go
+++ b/core/get.go
@@ -61,8 +61,6 @@ func Exists(pretty bool, index string, _type string, id string) (bool, error) {
 
 	var url string
 
-	var response map[string]interface{}
-
 	if len(_type) > 0 {
 		url = fmt.Sprintf("/%s/%s/%s?fields=_id%s", index, _type, id, api.Pretty(pretty))
 	} else {
@@ -75,7 +73,7 @@ func Exists(pretty bool, index string, _type string, id string) (bool, error) {
 		fmt.Println(err)
 	}
 
-	httpStatusCode, _, err := req.Do(&response)
+	httpStatusCode, _, err := req.Do(nil)
 
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Exists shouldn't return error when the document isn't found. Currently it does because Do and then DoResponse is trying to Unmarshal the body of this request. Because the request verb is HEAD there is no payload and the following error occurs "unexpected end of JSON input". Passing nil here will prevent the  conditions here (https://github.com/mattbaird/elastigo/blob/master/api/request.go#L104) from being met and therefore prevent this error. This doesn't seem to interfere with anything. Let me know if I have overlooked anything.
