### PR TITLE
Correct Sendor -> Sender and add alias for backwards compatibility

### DIFF
--- a/core/bulk_test.go
+++ b/core/bulk_test.go
@@ -54,7 +54,7 @@ func CloseInt(a, b int) bool {
 func TestBulkIndexerBasic(t *testing.T) {
 	InitTests(true)
 	indexer := NewBulkIndexer(3)
-	indexer.BulkSendor = func(buf *bytes.Buffer) error {
+	indexer.BulkSender = func(buf *bytes.Buffer) error {
 		messageSets += 1
 		totalBytesSent += buf.Len()
 		buffers = append(buffers, buf)
@@ -95,7 +95,7 @@ func TestBulkUpdate(t *testing.T) {
 	InitTests(true)
 	api.Port = "9200"
 	indexer := NewBulkIndexer(3)
-	indexer.BulkSendor = func(buf *bytes.Buffer) error {
+	indexer.BulkSender = func(buf *bytes.Buffer) error {
 		messageSets += 1
 		totalBytesSent += buf.Len()
 		buffers = append(buffers, buf)
@@ -150,7 +150,7 @@ func TestBulkSmallBatch(t *testing.T) {
 	indexersm.BufferDelayMax = 100 * time.Millisecond
 	indexersm.BulkMaxDocs = 2
 	messageSets = 0
-	indexersm.BulkSendor = func(buf *bytes.Buffer) error {
+	indexersm.BulkSender = func(buf *bytes.Buffer) error {
 		messageSets += 1
 		return BulkSend(buf)
 	}
@@ -208,7 +208,7 @@ func BenchmarkBulkSend(b *testing.B) {
 	b.StartTimer()
 	totalBytes := 0
 	sets := 0
-	GlobalBulkIndexer.BulkSendor = func(buf *bytes.Buffer) error {
+	GlobalBulkIndexer.BulkSender = func(buf *bytes.Buffer) error {
 		totalBytes += buf.Len()
 		sets += 1
 		//log.Println("got bulk")
@@ -244,7 +244,7 @@ func BenchmarkBulkSendBytes(b *testing.B) {
 	b.StartTimer()
 	totalBytes := 0
 	sets := 0
-	GlobalBulkIndexer.BulkSendor = func(buf *bytes.Buffer) error {
+	GlobalBulkIndexer.BulkSender = func(buf *bytes.Buffer) error {
 		totalBytes += buf.Len()
 		sets += 1
 		return BulkSend(buf)

--- a/core/example_test.go
+++ b/core/example_test.go
@@ -86,8 +86,8 @@ func ExampleBulkIndexer_errorsmarter() {
 // The inspecting the response
 func ExampleBulkIndexer_responses() {
 	indexer := core.NewBulkIndexer(10)
-	// Create a custom Sendor Func, to allow inspection of response/error
-	indexer.BulkSendor = func(buf *bytes.Buffer) error {
+	// Create a custom Sender Func, to allow inspection of response/error
+	indexer.BulkSender = func(buf *bytes.Buffer) error {
 		// @buf is the buffer of docs about to be written
 		respJson, err := api.DoCommand("POST", "/_bulk", buf)
 		if err != nil {

--- a/core/test_test.go
+++ b/core/test_test.go
@@ -116,7 +116,7 @@ func LoadTestData() {
 	docCt := 0
 	errCt := 0
 	indexer := NewBulkIndexer(20)
-	indexer.BulkSendor = func(buf *bytes.Buffer) error {
+	indexer.BulkSender = func(buf *bytes.Buffer) error {
 		log.Printf("Sent %d bytes total %d docs sent", buf.Len(), docCt)
 		req, err := api.ElasticSearchRequest("POST", "/_bulk")
 		if err != nil {


### PR DESCRIPTION
This -shouldn't- be a breaking change; can't say for certain as the
BulkSendor property is exposed though.
