### PR TITLE
Fixed "json: error calling MarshalJSON for type json.RawMessage"

### DIFF
--- a/core/search.go
+++ b/core/search.go
@@ -139,12 +139,12 @@ func (h *Hits) Len() int {
 }
 
 type Hit struct {
-	Index  string          `json:"_index"`
-	Type   string          `json:"_type,omitempty"`
-	Id     string          `json:"_id"`
-	Score  Float32Nullable `json:"_score,omitempty"` // Filters (no query) dont have score, so is null
-	Source json.RawMessage `json:"_source"`          // marshalling left to consumer
-	Fields json.RawMessage `json:"fields"`           // when a field arg is passed to ES, instead of _source it returns fields
+	Index  string           `json:"_index"`
+	Type   string           `json:"_type,omitempty"`
+	Id     string           `json:"_id"`
+	Score  Float32Nullable  `json:"_score,omitempty"` // Filters (no query) dont have score, so is null
+	Source *json.RawMessage `json:"_source"`          // marshalling left to consumer
+	Fields *json.RawMessage `json:"fields"`           // when a field arg is passed to ES, instead of _source it returns fields
 }
 
 // Elasticsearch returns some invalid (according to go) json, with floats having...

--- a/core/search_test.go
+++ b/core/search_test.go
@@ -12,6 +12,7 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"github.com/bmizerany/assert"
 	"testing"
@@ -28,4 +29,23 @@ func TestSearchRequest(t *testing.T) {
 	assert.T(t, &out != nil && err == nil, fmt.Sprintf("Should get docs"))
 	assert.T(t, out.Hits.Len() == 10, fmt.Sprintf("Should have 10 docs but was %v", out.Hits.Len()))
 	assert.T(t, CloseInt(out.Hits.Total, 588), fmt.Sprintf("Should have 588 hits but was %v", out.Hits.Total))
+}
+
+func TestSearchResultToJSON(t *testing.T) {
+	qry := map[string]interface{}{
+		"query": map[string]interface{}{
+			"wildcard": map[string]string{"actor": "a*"},
+		},
+	}
+	out, err := SearchRequest(true, "github", "", qry, "", 0)
+
+	if err != nil {
+		t.Error(err)
+	}
+
+	_, err = json.Marshal(out.Hits.Hits)
+
+	if err != nil {
+		t.Error(err)
+	}
 }


### PR DESCRIPTION
When I try:

``` go
out, err := SearchRequest(true, "github", "", qry, "", 0)
if err != nil {
  t.Error(err)
}

_, err = json.Marshal(out.Hits.Hits)
```

I receive:

```
--- FAIL: TestSearchResultToJSON (0.01 seconds)
  search_test.go:48: json: error calling MarshalJSON for type json.RawMessage: unexpected end of JSON input
FAIL
exit status 1
```

My commit fix it!
