### PR TITLE
Fix NodeStatsIndicesResponse.Search

### DIFF
--- a/api/clusterstatresponses.go
+++ b/api/clusterstatresponses.go
@@ -54,7 +54,7 @@ type NodeStatsIndicesResponse struct {
 	Store    NodeStatsIndicesStoreResponse
 	Indexing NodeStatsIndicesIndexingResponse
 	Get      NodeStatsIndicesGetResponse
-	Search   NodeStatsIndicesStoreResponse
+	Search   NodeStatsIndicesSearchResponse
 }
 
 type NodeStatsIndicesDocsResponse struct {


### PR DESCRIPTION
NodeStatsIndicesResponse.Search was of type NodeStatsIndicesStoreResponse, rather than type NodeStatsIndicesSearchResponse.
