### PR TITLE
Sprintf() called w/o interface{} args

### DIFF
--- a/cluster/health.go
+++ b/cluster/health.go
@@ -28,7 +28,7 @@ func Health(indices ...string) (api.ClusterHealthResponse, error) {
 	if len(indices) > 0 {
 		url = fmt.Sprintf("/_cluster/health/%s?%s", strings.Join(indices, ","))
 	} else {
-		url = fmt.Sprintf("/_cluster/health?%s")
+		url = "/_cluster/health"
 	}
 	body, err := api.DoCommand("GET", url, nil, nil)
 	if err != nil {


### PR DESCRIPTION
The original call will result in "/_cluster/health/%!s(MISSING)"

See: http://play.golang.org/p/PaKn5IjFl1

Presumably this was meant to be "/_cluster/health" with no additional arguments?
