### PR TITLE
Call to Sprintf malformed

### DIFF
--- a/cluster/health.go
+++ b/cluster/health.go
@@ -26,7 +26,7 @@ func Health(indices ...string) (api.ClusterHealthResponse, error) {
 	var url string
 	var retval api.ClusterHealthResponse
 	if len(indices) > 0 {
-		url = fmt.Sprintf("/_cluster/health/%s?%s", strings.Join(indices, ","))
+		url = fmt.Sprintf("/_cluster/health/%s", strings.Join(indices, ","))
 	} else {
 		url = "/_cluster/health"
 	}


### PR DESCRIPTION
See: http://play.golang.org/p/OoZfNXBmHA

For just indices, a single '%s' suffices. I think the second '%s' may have been intended for params (http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/cluster-health.html), but adding those as an argument to the Health function would be a breaking API change. Let me know if you would like that change made to the API.
