### PR TITLE
Replaced "error" with "res_err"

### DIFF
--- a/api/baseRequest.go
+++ b/api/baseRequest.go
@@ -56,9 +56,9 @@ func DoCommand(method string, url string, args map[string]interface{}, data inte
 
 		jsonErr := json.Unmarshal(body, &response)
 		if jsonErr == nil {
-			if error, ok := response["error"]; ok {
+			if res_err, ok := response["error"]; ok {
 				status, _ := response["status"]
-				return body, ESError{time.Now(), fmt.Sprintf("Error [%s] Status [%v]", error, status), httpStatusCode}
+				return body, ESError{time.Now(), fmt.Sprintf("Error [%s] Status [%v]", res_err, status), httpStatusCode}
 			}
 		}
 		return body, jsonErr


### PR DESCRIPTION
"error" is a reserved keyword in Go, as it is a built-in type. Using "error" as a variable, although possible (and "correct", as far as the compiler is concerned), is ill-advised.
