### PR TITLE
Make logging verbosity configurable.

### DIFF
--- a/client.go
+++ b/client.go
@@ -33,6 +33,7 @@ func main() {
 	flag.Parse()
 	log.SetFlags(log.Ltime | log.Lshortfile)
 	api.Domain = *eshost
+	core.VerboseLogging = true
 	response, _ := core.Index("twitter", "tweet", "1", nil, NewTweet("kimchy", "Search is cool"))
 	indices.Flush()
 	log.Printf("Index OK: %v", response.Ok)

--- a/core/index.go
+++ b/core/index.go
@@ -22,6 +22,10 @@ import (
 	"github.com/mattbaird/elastigo/api"
 )
 
+// VerboseLogging controls whether elastigo will log more information
+// about its actions. Set it to false for less logging.
+var VerboseLogging bool = true;
+
 // Index adds or updates a typed JSON document in a specific index, making it searchable, creating an index
 // if it did not exist.
 // if id is omited, op_type 'create' will be passed and http method will default to "POST"
@@ -56,7 +60,9 @@ func IndexWithParameters(index string, _type string, id string, parentId string,
 	} else {
 		method = "PUT"
 	}
-	log.Printf("about to :%v %v %s", url, args, data)
+	if VerboseLogging {
+		log.Printf("about to :%v %v %s", url, args, data)
+	}
 	body, err := api.DoCommand(method, url, args, data)
 	if err != nil {
 		return retval, err


### PR DESCRIPTION
Don't log every indexing event if `VerboseLogging` is set to `false`.
