### PR TITLE
Fixed memory leak

### DIFF
--- a/core/bulk.go
+++ b/core/bulk.go
@@ -294,7 +294,7 @@ func (b *BulkIndexer) startDocChannel() {
 func (b *BulkIndexer) send(buf *bytes.Buffer) {
 	//b2 := *b.buf
 	b.sendBuf <- buf
-	b.buf = new(bytes.Buffer)
+	b.buf.Reset()
 	b.docCt = 0
 }
 


### PR DESCRIPTION
b.buf = new(bytes.Buffer) was allocating memory that was not being released back to the OS.
You can reproduce the memory leak by indexing a large document or multiple documents using bulk index. 

The Reset() function seems to be the better approach.

Environment:
Mac OS X Mavericks
64 bit
