### PR TITLE
add RawJSON to SearchResult

### DIFF
--- a/core/search.go
+++ b/core/search.go
@@ -56,6 +56,7 @@ func SearchRequest(index string, _type string, args map[string]interface{}, quer
 			return retval, jsonErr
 		}
 	}
+	retval.RawJSON = body
 	return retval, err
 }
 
@@ -90,6 +91,7 @@ func SearchUri(index, _type string, args map[string]interface{}) (SearchResult, 
 			return retval, jsonErr
 		}
 	}
+	retval.RawJSON = body
 	return retval, err
 }
 
@@ -118,6 +120,7 @@ func Scroll(args map[string]interface{}, scroll_id string) (SearchResult, error)
 }
 
 type SearchResult struct {
+	RawJSON      []byte
 	Took         int             `json:"took"`
 	TimedOut     bool            `json:"timed_out"`
 	ShardStatus  api.Status      `json:"_shards"`


### PR DESCRIPTION
This is useful because for example "suggest" response can't currently be
decoded. If we have RawJSON then any type of response can be decoded by
anyone without having to make huge changes to the library.
