### PR TITLE
Fix misleading test case

### DIFF
--- a/lib/indicesputmapping_test.go
+++ b/lib/indicesputmapping_test.go
@@ -81,8 +81,8 @@ func TestPutMapping(t *testing.T) {
 			"multi_analyze": map[string]interface{}{
 				"type": "multi_field",
 				"fields": map[string]map[string]string{
-					"ma_analyzed":   {"type": "string", "index": "analyzed"},
-					"ma_unanalyzed": {"type": "string", "index": "un_analyzed"},
+					"ma_analyzed":    {"type": "string", "index": "analyzed"},
+					"ma_notanalyzed": {"type": "string", "index": "not_analyzed"},
 				},
 			},
 		},
@@ -100,8 +100,8 @@ func TestPutMapping(t *testing.T) {
 			"multi_analyze": map[string]interface{}{
 				"type": "multi_field",
 				"fields": map[string]map[string]string{
-					"ma_analyzed":   {"type": "string", "index": "analyzed"},
-					"ma_unanalyzed": {"type": "string", "index": "un_analyzed"},
+					"ma_analyzed":    {"type": "string", "index": "analyzed"},
+					"ma_notanalyzed": {"type": "string", "index": "not_analyzed"},
 				},
 			},
 			"nested": map[string]map[string]map[string]string{


### PR DESCRIPTION
Hi, I'm recreating the PR after rebasing to the most current master.
# 

The index value for "index the value exactly as specified" is not_analyzed : http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/mapping-intro.html#_literal_index_literal

However, in indices/putMapping_test.go it's using: un_analyzed which is invalid.

It's a bit misleading for people trying to use PutMapping by reading the test case like me. :p
