### PR TITLE
Better to not unmarshall the schema dependent source.

### DIFF
--- a/client.go
+++ b/client.go
@@ -16,9 +16,10 @@ package main
 import (
 	"encoding/json"
 	"flag"
-	elastigo "github.com/mattbaird/elastigo/lib"
 	"log"
 	"time"
+
+	elastigo "github.com/mattbaird/elastigo/lib"
 )
 
 var (

--- a/lib/baseresponse.go
+++ b/lib/baseresponse.go
@@ -17,16 +17,16 @@ import (
 )
 
 type BaseResponse struct {
-	Ok      bool        `json:"ok"`
-	Index   string      `json:"_index,omitempty"`
-	Type    string      `json:"_type,omitempty"`
-	Id      string      `json:"_id,omitempty"`
-	Source  interface{} `json:"_source,omitempty"` // depends on the schema you've defined
-	Version int         `json:"_version,omitempty"`
-	Found   bool        `json:"found,omitempty"`
-	Exists  bool        `json:"exists,omitempty"`
-	Created bool        `json:"created,omitempty"`
-	Matches []string    `json:"matches,omitempty"` // percolate matches
+	Ok      bool             `json:"ok"`
+	Index   string           `json:"_index,omitempty"`
+	Type    string           `json:"_type,omitempty"`
+	Id      string           `json:"_id,omitempty"`
+	Source  *json.RawMessage `json:"_source,omitempty"` // depends on the schema you've defined
+	Version int              `json:"_version,omitempty"`
+	Found   bool             `json:"found,omitempty"`
+	Exists  bool             `json:"exists,omitempty"`
+	Created bool             `json:"created,omitempty"`
+	Matches []string         `json:"matches,omitempty"` // percolate matches
 }
 
 // StatusInt is required because /_optimize, at least, returns its status as

--- a/lib/corebulk_test.go
+++ b/lib/corebulk_test.go
@@ -17,12 +17,13 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/araddon/gou"
-	"github.com/bmizerany/assert"
 	"log"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/araddon/gou"
+	"github.com/bmizerany/assert"
 )
 
 //  go test -bench=".*"
@@ -135,9 +136,11 @@ func XXXTestBulkUpdate(t *testing.T) {
 
 	response, err := c.Get("users", "user", "5", nil)
 	assert.T(t, err == nil, fmt.Sprintf("Should not have any errors  %v", err))
-	newCount := response.Source.(map[string]interface{})["count"]
+	m := make(map[string]interface{})
+	json.Unmarshal([]byte(*response.Source), &m)
+	newCount := m["count"]
 	assert.T(t, newCount.(float64) == 3,
-		fmt.Sprintf("Should have update count: %#v ... %#v", response.Source.(map[string]interface{})["count"], response))
+		fmt.Sprintf("Should have update count: %#v ... %#v", m["count"], response))
 }
 
 func TestBulkSmallBatch(t *testing.T) {

--- a/lib/coreget.go
+++ b/lib/coreget.go
@@ -22,7 +22,7 @@ import (
 // HEAD - checks for existence of the doc
 // http://www.elasticsearch.org/guide/reference/api/get.html
 // TODO: make this implement an interface
-func (c *Conn) get(index string, _type string, id string, args map[string]interface{}, source interface{}) (BaseResponse, error) {
+func (c *Conn) get(index string, _type string, id string, args map[string]interface{}, source *json.RawMessage) (BaseResponse, error) {
 	var url string
 	retval := BaseResponse{Source: source}
 	if len(_type) > 0 {
@@ -54,7 +54,7 @@ func (c *Conn) Get(index string, _type string, id string, args map[string]interf
 }
 
 // Same as Get but with custom source type.
-func (c *Conn) GetCustom(index string, _type string, id string, args map[string]interface{}, source interface{}) (BaseResponse, error) {
+func (c *Conn) GetCustom(index string, _type string, id string, args map[string]interface{}, source *json.RawMessage) (BaseResponse, error) {
 	return c.get(index, _type, id, args, source)
 }
 


### PR DESCRIPTION
Having the source un-marshaled into the interface there was requiring me to marshal and then un-marshal again to get the data into my structs. But the round trip also messed up some of the types in the process. This seems the more sensible approach.
