### PR TITLE
Fix PutMapping() to correctly handle 'nested' type

### DIFF
--- a/lib/indicesputmapping.go
+++ b/lib/indicesputmapping.go
@@ -87,7 +87,8 @@ func getProperties(t reflect.Type, prop map[string]interface{}) {
 			keyvalue := strings.Split(attr, ":")
 			attrMap[keyvalue[0]] = keyvalue[1]
 		}
-		if len(attrMap) == 0 {
+
+		if len(attrMap) == 0 || attrMap["type"] == "nested" {
 
 			// We are looking for tags on any inner struct, independently of
 			// whether the field is a struct, a pointer to struct, or a slice of structs
@@ -96,7 +97,6 @@ func getProperties(t reflect.Type, prop map[string]interface{}) {
 				targetType.Kind() == reflect.Slice {
 				targetType = field.Type.Elem()
 			}
-
 			if targetType.Kind() == reflect.Struct {
 				if field.Anonymous {
 					getProperties(targetType, prop)

--- a/lib/indicesputmapping_test.go
+++ b/lib/indicesputmapping_test.go
@@ -60,6 +60,7 @@ type TestStruct struct {
 	InnerP       *InnerStruct  `json:"pointer_to_inner"`
 	InnerS       []InnerStruct `json:"slice_of_inner"`
 	MultiAnalyze string        `json:"multi_analyze"`
+	NestedObject NestedStruct  `json:"nestedObject" elastic:"type:nested"`
 }
 
 type Embedded struct {
@@ -67,6 +68,10 @@ type Embedded struct {
 }
 
 type InnerStruct struct {
+	InnerField string `json:"innerField" elastic:"type:date"`
+}
+
+type NestedStruct struct {
 	InnerField string `json:"innerField" elastic:"type:date"`
 }
 
@@ -117,6 +122,12 @@ func TestPutMapping(t *testing.T) {
 			},
 			"slice_of_inner": map[string]map[string]map[string]string{
 				"properties": {
+					"innerField": {"type": "date"},
+				},
+			},
+			"nestedObject": map[string]interface{}{
+				"type": "nested",
+				"properties": map[string]map[string]string{
 					"innerField": {"type": "date"},
 				},
 			},


### PR DESCRIPTION
Added handling of 'nested' type to lib.PutMapping() function.

Reason:
Elastic-search contains abstraction called nested objects.
see http://www.elasticsearch.org/guide/en/elasticsearch/reference/1.4/mapping-nested-type.html
Nested objects can be specified in mapping, see http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/nested-mapping.html
This means that for fields that have tag `elastic:"type:nested"` applied, function lib.PutMapping() should investigate its inner fields (when type of field is structure/slice).

I split this pull-request into three separate commits. This way reviewing code should be easier.

I couldn't run all tests without failures as I hit the same issue as described here https://github.com/mattbaird/elastigo/issues/108
However all the tests that pass on my local workstation when run against freshly cloned repo at master branch also pass for my pull-request.
