### PR TITLE
Implement Lt method on *FilterOp, Gt method on *FilterOp is now an interface{} allowing it to accept date ranges

### DIFF
--- a/lib/searchfilter.go
+++ b/lib/searchfilter.go
@@ -181,8 +181,12 @@ func (f *FilterOp) To(to string) *FilterOp {
 	f.Range[f.curField]["to"] = to
 	return f
 }
-func (f *FilterOp) Gt(gt int) *FilterOp {
-	f.Range[f.curField]["gt"] = float64(gt)
+func (f *FilterOp) Gt(gt interface{}) *FilterOp {
+	f.Range[f.curField]["gt"] = gt
+	return f
+}
+func (f *FilterOp) Lt(lt interface{}) *FilterOp {
+	f.Range[f.curField]["lt"] = lt
 	return f
 }
 func (f *FilterOp) Exists(name string) *FilterOp {


### PR DESCRIPTION
Before Gt would only accept ints, meaning you couldn't do ranges on dates like documented [here](http://www.elasticsearch.org/guide/en/elasticsearch/guide/current/_ranges.html)

Also implement Lt
