### PR TITLE
LoadTestData obeys -host argument

### DIFF
--- a/lib/coretest_test.go
+++ b/lib/coretest_test.go
@@ -114,6 +114,7 @@ type GithubEvent struct {
 // This loads test data from github archives (~6700 docs)
 func LoadTestData() {
 	c := NewConn()
+	c.Domain = *eshost
 
 	c.DeleteIndex(testIndex)
 


### PR DESCRIPTION
LoadTestData creates its own connection and previously ignored the -host argument. Easy fix. :beers: 