### PR TITLE
Make `Conn` thread-safe

### DIFF
--- a/client.go
+++ b/client.go
@@ -32,7 +32,7 @@ func main() {
 	log.SetFlags(log.Ltime | log.Lshortfile)
 
 	c := elastigo.NewConn()
-	c.Domain = *eshost
+	c.SetDomain(*eshost)
 	response, _ := c.Index("twitter", "tweet", "1", nil, NewTweet("kimchy", "Search is cool"))
 	c.Flush()
 	log.Printf("Index OK: %v", response.Ok)

--- a/lib/baserequest.go
+++ b/lib/baserequest.go
@@ -52,14 +52,14 @@ func (c *Conn) DoCommand(method string, url string, args map[string]interface{},
 	}
 
 	// Copy request body for tracer
-	if c.RequestTracer != nil {
+	if c.requestTracer != nil {
 		requestBody, err := ioutil.ReadAll(req.Body)
 		if err != nil {
 			return body, err
 		}
 
 		req.SetBody(bytes.NewReader(requestBody))
-		c.RequestTracer(req.Method, req.URL.String(), string(requestBody))
+		c.requestTracer(req.Method, req.URL.String(), string(requestBody))
 	}
 
 	httpStatusCode, body, err = req.Do(&response)

--- a/lib/connection.go
+++ b/lib/connection.go
@@ -32,25 +32,26 @@ const (
 )
 
 type Conn struct {
-	// Maintain these for backwards compatibility
-	Protocol       string
-	Domain         string
-	ClusterDomains []string
-	Port           string
-	Username       string
-	Password       string
-	Hosts          []string
-	RequestTracer  func(method, url, body string)
-	hp             hostpool.HostPool
-	once           sync.Once
-	client         *http.Client
+	hp     hostpool.HostPool
+	once   sync.Once
+	client *http.Client
+
+	mu             sync.RWMutex // protects following fields
+	protocol       string
+	domain         string
+	clusterDomains []string
+	port           string
+	username       string
+	password       string
+	hosts          []string
 	transport      *http.Transport
+	requestTracer  func(method, url, body string)
 
 	// To compute the weighting scores, we perform a weighted average of recent response times,
 	// over the course of `DecayDuration`. DecayDuration may be set to 0 to use the default
 	// value of 5 minutes. The EpsilonValueCalculator uses this to calculate a score
 	// from the weighted average response time.
-	DecayDuration time.Duration
+	decayDuration time.Duration
 }
 
 func NewConn() *Conn {
@@ -68,25 +69,73 @@ func NewConn() *Conn {
 
 	return &Conn{
 		// Maintain these for backwards compatibility
-		Protocol:       DefaultProtocol,
-		Domain:         DefaultDomain,
-		ClusterDomains: []string{DefaultDomain},
-		Port:           DefaultPort,
-		DecayDuration:  time.Duration(DefaultDecayDuration * time.Second),
+		protocol:       DefaultProtocol,
+		domain:         DefaultDomain,
+		clusterDomains: []string{DefaultDomain},
+		port:           DefaultPort,
+		decayDuration:  time.Duration(DefaultDecayDuration * time.Second),
 
 		client:    &http.Client{Transport: t},
 		transport: t,
 	}
 }
 
+func (c *Conn) SetProtocol(protocol string) {
+	c.mu.Lock()
+	c.protocol = protocol
+	c.mu.Unlock()
+}
+
+func (c *Conn) SetDomain(domain string) {
+	c.mu.Lock()
+	c.domain = domain
+	c.mu.Unlock()
+}
+
+func (c *Conn) SetClusterDomains(domains []string) {
+	c.mu.Lock()
+	c.clusterDomains = domains
+	c.mu.Unlock()
+}
+
 func (c *Conn) SetPort(port string) {
-	c.Port = port
+	c.mu.Lock()
+	c.port = port
+	c.mu.Unlock()
+}
+
+func (c *Conn) SetUsername(username string) {
+	c.mu.Lock()
+	c.username = username
+	c.mu.Unlock()
+}
+
+func (c *Conn) SetPassword(password string) {
+	c.mu.Lock()
+	c.password = password
+	c.mu.Unlock()
 }
 
 func (c *Conn) SetHosts(newhosts []string) {
+	c.mu.Lock()
+	c.hosts = newhosts
+	c.mu.Unlock()
 
-	// Store the new host list
-	c.Hosts = newhosts
+	// Reinitialise the host pool Pretty naive as this will nuke the current
+	// hostpool, and therefore reset any scoring
+	c.initializeHostPool()
+}
+
+func (c *Conn) SetRequestTracer(tracer func(method, url, body string)) {
+	c.mu.Lock()
+	c.requestTracer = tracer
+	c.mu.Unlock()
+}
+
+func (c *Conn) SetDecayDuration(duration time.Duration) {
+	c.mu.Lock()
+	c.decayDuration = duration
+	c.mu.Unlock()
 
 	// Reinitialise the host pool Pretty naive as this will nuke the current
 	// hostpool, and therefore reset any scoring
@@ -98,15 +147,19 @@ func (c *Conn) SetMaxIdleConnsPerHost(n int) {
 		n = 0
 	}
 
+	c.mu.Lock()
 	c.transport.MaxIdleConnsPerHost = n
+	c.mu.Unlock()
 }
 
 // Set up the host pool to be used
 func (c *Conn) initializeHostPool() {
+	c.mu.Lock()
+	defer c.mu.Unlock()
 
 	// If no hosts are set, fallback to defaults
-	if len(c.Hosts) == 0 {
-		c.Hosts = append(c.Hosts, fmt.Sprintf("%s:%s", c.Domain, c.Port))
+	if len(c.hosts) == 0 {
+		c.hosts = append(c.hosts, fmt.Sprintf("%s:%s", c.domain, c.port))
 	}
 
 	// Epsilon Greedy is an algorithm that allows HostPool not only to
@@ -124,7 +177,7 @@ func (c *Conn) initializeHostPool() {
 		c.hp.Close()
 	}
 	c.hp = hostpool.NewEpsilonGreedy(
-		c.Hosts, c.DecayDuration, &hostpool.LinearEpsilonValueCalculator{})
+		c.hosts, c.decayDuration, &hostpool.LinearEpsilonValueCalculator{})
 }
 
 func (c *Conn) Close() {
@@ -138,17 +191,20 @@ func (c *Conn) NewRequest(method, path, query string) (*Request, error) {
 	// Get a host from the host pool
 	hr := c.hp.Get()
 
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	// Get the final host and port
-	host, portNum := splitHostnamePartsFromHost(hr.Host(), c.Port)
+	host, portNum := splitHostnamePartsFromHost(hr.Host(), c.port)
 
 	// Build request
 	var uri string
 	// If query parameters are provided, the add them to the URL,
 	// otherwise, leave them out
 	if len(query) > 0 {
-		uri = fmt.Sprintf("%s://%s:%s%s?%s", c.Protocol, host, portNum, path, query)
+		uri = fmt.Sprintf("%s://%s:%s%s?%s", c.protocol, host, portNum, path, query)
 	} else {
-		uri = fmt.Sprintf("%s://%s:%s%s", c.Protocol, host, portNum, path)
+		uri = fmt.Sprintf("%s://%s:%s%s", c.protocol, host, portNum, path)
 	}
 	req, err := http.NewRequest(method, uri, nil)
 	if err != nil {
@@ -157,8 +213,8 @@ func (c *Conn) NewRequest(method, path, query string) (*Request, error) {
 	req.Header.Add("Accept", "application/json")
 	req.Header.Add("User-Agent", "elasticSearch/"+Version+" ("+runtime.GOOS+"-"+runtime.GOARCH+")")
 
-	if c.Username != "" || c.Password != "" {
-		req.SetBasicAuth(c.Username, c.Password)
+	if c.username != "" || c.password != "" {
+		req.SetBasicAuth(c.username, c.password)
 	}
 
 	newRequest := &Request{

--- a/lib/corebulk_test.go
+++ b/lib/corebulk_test.go
@@ -118,7 +118,7 @@ func XXXTestBulkUpdate(t *testing.T) {
 
 	InitTests(true)
 	c := NewTestConn()
-	c.Port = "9200"
+	c.SetPort("9200")
 	indexer := c.NewBulkIndexer(3)
 	indexer.Sender = func(buf *bytes.Buffer) error {
 		messageSets += 1
@@ -226,9 +226,9 @@ func TestBulkDelete(t *testing.T) {
 func XXXTestBulkErrors(t *testing.T) {
 	// lets set a bad port, and hope we get a conn refused error?
 	c := NewTestConn()
-	c.Port = "27845"
+	c.SetPort("27845")
 	defer func() {
-		c.Port = "9200"
+		c.SetPort("9200")
 	}()
 	indexer := c.NewBulkIndexerErrors(10, 1)
 	indexer.Start()

--- a/lib/coretest_test.go
+++ b/lib/coretest_test.go
@@ -53,7 +53,7 @@ func InitTests(startIndexer bool) *Conn {
 		flag.Parse()
 		hasStartedTesting = true
 		log.SetFlags(log.Ltime | log.Lshortfile)
-		c.Domain = *eshost
+		c.SetDomain(*eshost)
 	}
 	if startIndexer && !bulkStarted {
 		bulkStarted = true
@@ -77,7 +77,7 @@ func InitTests(startIndexer bool) *Conn {
 
 func NewTestConn() *Conn {
 	c := NewConn()
-	c.Domain = *eshost
+	c.SetDomain(*eshost)
 	return c
 }
 
@@ -114,7 +114,7 @@ type GithubEvent struct {
 // This loads test data from github archives (~6700 docs)
 func LoadTestData() {
 	c := NewConn()
-	c.Domain = *eshost
+	c.SetDomain(*eshost)
 
 	c.DeleteIndex(testIndex)
 

--- a/lib/indicesdeletemapping_test.go
+++ b/lib/indicesdeletemapping_test.go
@@ -1,11 +1,11 @@
 package elastigo
 
 import (
-	"testing"
-	"net/http/httptest"
 	"net/http"
+	"net/http/httptest"
 	"net/url"
 	"strings"
+	"testing"
 )
 
 func TestDeleteMapping(t *testing.T) {
@@ -29,10 +29,10 @@ func TestDeleteMapping(t *testing.T) {
 
 	c := NewTestConn()
 
-	c.Domain = strings.Split(serverURL.Host, ":")[0]
-	c.Port = strings.Split(serverURL.Host, ":")[1]
+	c.SetDomain(strings.Split(serverURL.Host, ":")[0])
+	c.SetPort(strings.Split(serverURL.Host, ":")[1])
 
-	_, err := c.DeleteMapping("this","exists")
+	_, err := c.DeleteMapping("this", "exists")
 	if err != nil {
 		t.Errorf("Expected no error and got, %s", err)
 	}

--- a/lib/indicesputmapping_test.go
+++ b/lib/indicesputmapping_test.go
@@ -38,8 +38,8 @@ func setup(t *testing.T) *Conn {
 		t.Fatalf("Error: %v", err)
 	}
 
-	c.Domain = strings.Split(serverURL.Host, ":")[0]
-	c.Port = strings.Split(serverURL.Host, ":")[1]
+	c.SetDomain(strings.Split(serverURL.Host, ":")[0])
+	c.SetPort(strings.Split(serverURL.Host, ":")[1])
 
 	return c
 }

--- a/lib/request.go
+++ b/lib/request.go
@@ -25,9 +25,9 @@ import (
 )
 
 type Request struct {
-	*http.Client
 	*http.Request
 	hostResponse hostpool.HostPoolResponse
+	client       *http.Client
 }
 
 func (r *Request) SetBodyJson(data interface{}) error {
@@ -75,12 +75,7 @@ func (r *Request) Do(v interface{}) (int, []byte, error) {
 }
 
 func (r *Request) DoResponse(v interface{}) (*http.Response, []byte, error) {
-	var client = r.Client
-	if client == nil {
-		client = http.DefaultClient
-	}
-
-	res, err := client.Do(r.Request)
+	res, err := r.client.Do(r.Request)
 	// Inform the HostPool of what happened to the request and allow it to update
 	r.hostResponse.Mark(err)
 	if err != nil {

--- a/tutorial/start_1.go
+++ b/tutorial/start_1.go
@@ -29,10 +29,10 @@ func main() {
 	flag.Parse()
 
 	// Trace all requests
-	c.RequestTracer = func(method, url, body string) {
+	c.SetRequestTracer(func(method, url, body string) {
 		log.Printf("Requesting %s %s", method, url)
 		log.Printf("Request body: %s", body)
-	}
+	})
 
 	fmt.Println("host = ", *host)
 	// Set the Elasticsearch Host to Connect to


### PR DESCRIPTION
:fire::fire::fire: **_This is a breaking change!**_ :fire::fire::fire:

Thread safety is an important improvement since it enables HTTP connection reuse. However, in order to pull it off I had to protect all public properties of `Conn`. This patch adds setter methods for all previously public properties. I didn't add getters since this would increase shared memory surface area, and similar libraries like `database/sql` don't expose them. Developers interested in this information can cache what they send us.

There's a bit of read locking required since many `Conn` properties are mutable. Ideally all state would be defined by the constructor, and we could remove these locks, but that would be an even more drastic change so I omitted it for now.
