### PR TITLE
add support for search_type argument

### DIFF
--- a/lib/searchsearch.go
+++ b/lib/searchsearch.go
@@ -194,3 +194,8 @@ func (s *SearchDsl) Scroll(duration string) *SearchDsl {
 	s.args["scroll"] = duration
 	return s
 }
+
+func (s *SearchDsl) SearchType(searchType string) *SearchDsl {
+	s.args["search_type"] = searchType
+	return s
+}


### PR DESCRIPTION
only thoroughly checked the docs/code, not sure if it's supported yet

reference:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-request-search-type.html

which is useful when:
http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/search-aggregations.html#_returning_only_aggregation_results

may also add AggregationOnly() for more convenience