### PR TITLE
allowed map type for settings param of CreateIndexWithSettings

### DIFF
--- a/lib/indicescreateindex.go
+++ b/lib/indicescreateindex.go
@@ -46,9 +46,9 @@ func (c *Conn) CreateIndexWithSettings(index string, settings interface{}) (Base
 	var url string
 	var retval BaseResponse
 
-	settingsType := reflect.TypeOf(settings)
-	if settingsType.Kind() != reflect.Struct {
-		return retval, fmt.Errorf("Settings kind was not struct")
+	settingsType := reflect.TypeOf(settings).Kind()
+	if settingsType != reflect.Struct && settingsType != reflect.Map {
+		return retval, fmt.Errorf("Settings kind was not struct or map")
 	}
 
 	requestBody, err := json.Marshal(settings)


### PR DESCRIPTION
Writing settings parameter as struct can be unreadable, shown as below

```go
CreateIndexWithSettings("index_name", struct {
    Settings map[string]interface{} `json:"settings"`
}{
    Settings: map[string]interface{}{
        "index" : map[string]int{//...},
        "analysis": map[string]interface{}{
            // some other string-interface maps and maps
        },
    },
})
```

map makes our life easier right here :) i allowed struct type for backward. i don't examine yet other methods, if i meet like this, i will handle. thanks