### PR TITLE
Open close indices

### DIFF
--- a/lib/clusternodesinfo.go
+++ b/lib/clusternodesinfo.go
@@ -79,8 +79,9 @@ type Cluster struct {
 }
 
 type OS struct {
-	RefreshInterval     int `json:"refresh_interval,omitempty"`
-	AvailableProcessors int `json:"available_processors,omitempty"`
+	RefreshInterval     int  `json:"refresh_interval,omitempty"`
+	AvailableProcessors int  `json:"available_processors,omitempty"`
+	CPU                 *CPU `json:"cpu,omitempty"`
 }
 
 type CPU struct {

--- a/lib/indicesopencloseindex.go
+++ b/lib/indicesopencloseindex.go
@@ -11,54 +11,41 @@
 
 package elastigo
 
-
 import (
 	"encoding/json"
 	"fmt"
 )
 
-func (c *Conn) OpenIndex(index string) (BaseResponse, error) {
-
-	var url string
-	var retval BaseResponse
-
-	if len(index) > 0 {
-		url = fmt.Sprintf("/%s/_open", index)
-	} else {
-		url = fmt.Sprintf("/_open")
-	}
-
-	body, errDo := c.DoCommand("POST", url, nil, nil)
-	if errDo != nil {
-		return retval, errDo
-	}
-
-	jsonErr := json.Unmarshal(body, &retval)
-	if jsonErr != nil {
-		return retval, jsonErr
-	}
-
-	return retval, errDo
+func (c *Conn) OpenIndices() (BaseResponse, error) {
+	return c.openCloseOperation("_all", "_open")
 }
 
+func (c *Conn) CloseIndices() (BaseResponse, error) {
+	return c.openCloseOperation("_all", "_close")
+}
 
+func (c *Conn) OpenIndex(index string) (BaseResponse, error) {
+	return c.openCloseOperation(index, "_open")
+}
 
 func (c *Conn) CloseIndex(index string) (BaseResponse, error) {
+	return c.openCloseOperation(index, "_close")
+}
 
+func (c *Conn) openCloseOperation(index, mode string) (BaseResponse, error) {
 	var url string
 	var retval BaseResponse
 
 	if len(index) > 0 {
-		url = fmt.Sprintf("/%s/_close", index)
+		url = fmt.Sprintf("/%s/%s", index, mode)
 	} else {
-		url = fmt.Sprintf("/_close")
+		url = fmt.Sprintf("/%s", mode)
 	}
 
 	body, errDo := c.DoCommand("POST", url, nil, nil)
 	if errDo != nil {
 		return retval, errDo
 	}
-
 	jsonErr := json.Unmarshal(body, &retval)
 	if jsonErr != nil {
 		return retval, jsonErr


### PR DESCRIPTION
The current version doesn't work for close and open all indices. (API change I guess, you need to use _all in a explicit way)
This patch fix the problem with two function OpenIndices and CloseIndices