### PR TITLE
Change FieldAggregate.Size type to *int

### DIFF
--- a/lib/searchaggregate.go
+++ b/lib/searchaggregate.go
@@ -16,7 +16,7 @@ type AggregateDsl struct {
 
 type FieldAggregate struct {
 	Field string `json:"field"`
-	Size  int    `json:"size,omitempty"`
+	Size  *int   `json:"size,omitempty"`
 }
 
 /**
@@ -152,7 +152,7 @@ func (d *AggregateDsl) Terms(field string) *AggregateDsl {
 }
 
 func (d *AggregateDsl) TermsWithSize(field string, size int) *AggregateDsl {
-	d.Type = FieldAggregate{Field: field, Size: size}
+	d.Type = FieldAggregate{Field: field, Size: &size}
 	d.TypeName = "terms"
 	return d
 }

--- a/lib/searchaggregate_test.go
+++ b/lib/searchaggregate_test.go
@@ -21,6 +21,7 @@ func TestAggregateDsl(t *testing.T) {
 	global := Aggregate("global").Global()
 	missing := Aggregate("missing_price").Missing("price")
 	terms := Aggregate("terms_price").Terms("price")
+	termsSize := Aggregate("terms_price_size").TermsWithSize("price", 0)
 	significantTerms := Aggregate("significant_terms_price").SignificantTerms("price")
 	histogram := Aggregate("histogram_price").Histogram("price", 50)
 
@@ -38,6 +39,7 @@ func TestAggregateDsl(t *testing.T) {
 		global,
 		missing,
 		terms,
+		termsSize,
 		significantTerms,
 		histogram,
 	)
@@ -96,6 +98,9 @@ func TestAggregateDsl(t *testing.T) {
 						},
 						"terms_price":{
 							"terms": { "field": "price" }
+						},
+						"terms_price_size":{
+							"terms": { "field": "price", "size": 0 }
 						},
 						"significant_terms_price":{
 							"significant_terms": { "field": "price" }


### PR DESCRIPTION
ElasticSearch has default query result size limitation 10 if size field is not provided. And if size is 0, the size of result is unlimited.
If I query using this function with size 0, the `omitempty` option will prune out `size` field and trying get result with default size limitation 10.
This change can prevent the situation above.