### PR TITLE
Add support for multi-match queries in the dsl

### DIFF
--- a/lib/searchquery.go
+++ b/lib/searchquery.go
@@ -61,9 +61,10 @@ type QueryDsl struct {
 
 // The core Query Syntax can be embedded as a child of a variety of different parents
 type QueryEmbed struct {
-	MatchAll *MatchAll         `json:"match_all,omitempty"`
-	Terms    map[string]string `json:"term,omitempty"`
-	Qs       *QueryString      `json:"query_string,omitempty"`
+	MatchAll   *MatchAll         `json:"match_all,omitempty"`
+	Terms      map[string]string `json:"term,omitempty"`
+	Qs         *QueryString      `json:"query_string,omitempty"`
+	MultiMatch *MultiMatch       `json:"multi_match,omitempty"`
 	//Exist    string            `json:"_exists_,omitempty"`
 }
 
@@ -72,7 +73,7 @@ type QueryEmbed struct {
 func (qd *QueryDsl) MarshalJSON() ([]byte, error) {
 	q := qd.QueryEmbed
 	hasQuery := false
-	if q.Qs != nil || len(q.Terms) > 0 || q.MatchAll != nil {
+	if q.Qs != nil || len(q.Terms) > 0 || q.MatchAll != nil || q.MultiMatch != nil {
 		hasQuery = true
 	}
 	// If a query has a
@@ -157,6 +158,17 @@ func (q *QueryDsl) Fields(fields, search, exists, missing string) *QueryDsl {
 func (q *QueryDsl) Filter(f *FilterOp) *QueryDsl {
 	q.FilterVal = f
 	return q
+}
+
+// MultiMatch allows searching against multiple fields.
+func (q *QueryDsl) MultiMatch(s string, fields []string) *QueryDsl {
+	q.QueryEmbed.MultiMatch = &MultiMatch{Query: s, Fields: fields}
+	return q
+}
+
+type MultiMatch struct {
+	Query  string   `json:"query"`
+	Fields []string `json:"fields"`
 }
 
 type MatchAll struct {


### PR DESCRIPTION
This lets you search for a single term against multiple fields:

```
elastigo.Query().MultiMatch("fish", []string{"title", "description"}) 
```