### PR TITLE
Add setter method for boolean filter in dsl

### DIFF
--- a/lib/searchfilter.go
+++ b/lib/searchfilter.go
@@ -44,6 +44,12 @@ func (f *FilterWrap) String() string {
 	return fmt.Sprintf(`fopv: %d:%v`, len(f.filters), f.filters)
 }
 
+// Bool sets the type of boolean filter to use.
+// Accepted values are "and" and "or".
+func (f *FilterWrap) Bool(s string) {
+	f.boolClause = s
+}
+
 // Custom marshalling to support the query dsl
 func (f *FilterWrap) addFilters(fl []interface{}) {
 	if len(fl) > 1 {


### PR DESCRIPTION
The bool filter already existed, but wasn't exposed, so it always defaulted to "and".