### PR TITLE
adding helper for bulk update with script

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -333,6 +333,13 @@ func (b *BulkIndexer) Delete(index, _type, id string, refresh bool) {
 	return
 }
 
+func (b *BulkIndexer) UpdateWithWithScript(index string, _type string, id, ttl string, date *time.Time, script string, refresh bool) error {
+
+	var data map[string]interface{} = make(map[string]interface{})
+	data["script"] = script
+	return b.Update(index, _type, id, ttl, date, data, refresh)
+}
+
 func (b *BulkIndexer) UpdateWithPartialDoc(index string, _type string, id, ttl string, date *time.Time, partialDoc interface{}, upsert bool, refresh bool) error {
 
 	var data map[string]interface{} = make(map[string]interface{})


### PR DESCRIPTION
Needed a quick fix for using scripts in bulk updates. Works with the following test but let me know if you want me to add something to corebulk_test.go

```
func TestElasticScript(t *testing.T) {
	indexer := elastic.Conn.NewBulkIndexerErrors(ElasticMaxConns, 2)
	defer elastic.Conn.DeleteIndex("twitter")

	done := make(chan struct{}, 1)
	defer close(done)
	go func() {
		for {
			select {
			case err := <-indexer.ErrorChannel:
				t.Error(err)
			case <-done:
				return
			}
		}
	}()

	indexer.Start()
	indexer.Index("twitter", "user", "10", "", nil, `{"name":"bob","val":15}`, true)
	time.Sleep(time.Millisecond * 10)
	indexer.Stop()

	indexer.Start()

	tm := time.Now().UTC()
	indexer.UpdateWithWithScript(
		"twitter", // index
		"user",    // type
		"10",      // id
		"",        // ttl
		&tm,       // time
		"ctx._source.val+=20", //script
		true, // refresh
	)

	time.Sleep(time.Millisecond * 10)
	indexer.Stop()

	response, err := elastic.Conn.Get("twitter", "user", "10", nil)
	if err != nil {
		t.Fatal(err)
	}
	t.Log(string(*response.Source))

	if !strings.Contains(string(*response.Source), "35") {
		t.Error("did not find changed value")
	}
}

```