### PR TITLE
BulkIndexing Fix

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -136,6 +136,7 @@ func (b *BulkIndexer) Start() {
 		b.startDocChannel()
 		b.startTimer()
 		ch := <-b.shutdownChan
+		time.Sleep(2 * time.Millisecond)
 		b.Flush()
 		b.shutdown()
 		ch <- struct{}{}


### PR DESCRIPTION
Insert a milli-sleep after Stop() has been called to let other goros set the buffer before flushing. Without this, a quick (faster than the timer), small (smaller than the max size) bulk write will never actually be sent, as when Flush() is called, the docCount is errantly 0. 

A "better" way to solve it is with a semaphore, but that's more invasive than I care to get at the moment, as a 2milli sleep suffices.

Example code

    c := elastigo.NewConn()
    indexer := c.NewBulkIndexerErrors(10, 60)
    indexer.Start()
    indexer.Index("twitter", "user", "1", "", nil, `{"name":"bob"}`, true)
    indexer.Stop()