### PR TITLE
Add support for multiple filters in QueryDsl

### DIFF
--- a/lib/searchquery.go
+++ b/lib/searchquery.go
@@ -56,7 +56,7 @@ some ways to serialize
 */
 type QueryDsl struct {
 	QueryEmbed
-	FilterVal *FilterOp `json:"filter,omitempty"`
+	FilterVal *FilterWrap `json:"filter,omitempty"`
 }
 
 // The core Query Syntax can be embedded as a child of a variety of different parents
@@ -101,11 +101,10 @@ func (q *QueryDsl) All() *QueryDsl {
 // Limit the query to this range
 func (q *QueryDsl) Range(fop *FilterOp) *QueryDsl {
 	if q.FilterVal == nil {
-		q.FilterVal = fop
-		return q
+		q.FilterVal = NewFilterWrap()
 	}
 	// TODO:  this is not valid, refactor
-	q.FilterVal.Add(fop)
+	q.FilterVal.addFilters([]interface{}{fop})
 	return q
 }
 
@@ -167,7 +166,10 @@ func (q *QueryDsl) Fields(fields, search, exists, missing string) *QueryDsl {
 
 // Filter this query
 func (q *QueryDsl) Filter(f *FilterOp) *QueryDsl {
-	q.FilterVal = f
+	if q.FilterVal == nil {
+		q.FilterVal = NewFilterWrap()
+	}
+	q.FilterVal.addFilters([]interface{}{f})
 	return q
 }
 

--- a/lib/searchquery.go
+++ b/lib/searchquery.go
@@ -165,11 +165,11 @@ func (q *QueryDsl) Fields(fields, search, exists, missing string) *QueryDsl {
 }
 
 // Filter this query
-func (q *QueryDsl) Filter(f *FilterOp) *QueryDsl {
+func (q *QueryDsl) Filter(fl ...interface{}) *QueryDsl {
 	if q.FilterVal == nil {
 		q.FilterVal = NewFilterWrap()
 	}
-	q.FilterVal.addFilters([]interface{}{f})
+	q.FilterVal.addFilters(fl)
 	return q
 }
 


### PR DESCRIPTION
I'm interested in adding support for multiple filters to the QueryDsl in the same way it is currently done in FilterDsl. At the moment the user can only specify filters for a filtered query through `FilterOp` structure, whereas it should be `FilterWrap` to allow multiple filters. This should resolve #66. 

Not sure how it sits with PR #177, which changes the Filter API but doesn't seem to touch the QueryDsl - happy to rework this once that gets merged if it is easier.