### PR TITLE
added status field to CatIndexInfo struct

### DIFF
--- a/lib/catresponses.go
+++ b/lib/catresponses.go
@@ -2,6 +2,7 @@ package elastigo
 
 type CatIndexInfo struct {
 	Health   string
+	Status   string
 	Name     string
 	Shards   int
 	Replicas int


### PR DESCRIPTION
Fixes #208 Using this in an application that requires the name and status of the index.