### PR TITLE
Update Percolate to unmarshal response into a valid struct

### DIFF
--- a/lib/corepercolate.go
+++ b/lib/corepercolate.go
@@ -16,9 +16,6 @@ import (
 	"fmt"
 )
 
-//{"took":9,"_shards":{"total":3,"successful":3,"failed":0},"total":3,
-//"matches":[{"_index":"test-geoevents-20150706-115234","_id":"nyc,West Village"},{"_index":"test-geoevents-20150706-115234","_id":"nyc,Manhattan"},{"_index":"test-geoevents-20150706-115234","_id":"nyc,Greenwich Village"}]}
-
 type PercolatorResult struct {
 	SearchResult
 	Matches []PercolatorMatch `json:"matches"`
@@ -29,19 +26,12 @@ type PercolatorMatch struct {
 	Id    string `json:"_id"`
 }
 
-// RegisterPercolate allows the caller to register queries against an index,
-// and then send percolate requests which include a doc, and getting back the
-// queries that match on that doc out of the set of registered queries.  Think
-// of it as the reverse operation of indexing and then searching. Instead of
-// sending docs, indexing them, and then running queries. One sends queries,
-// registers them, and then sends docs and finds out which queries match that
-// doc.
-// see http://www.elasticsearch.org/guide/reference/api/percolate.html
-func (c *Conn) RegisterPercolate(index string, name string, args map[string]interface{}, query OneTermQuery) (BaseResponse, error) {
+// See http://www.elasticsearch.org/guide/reference/api/percolate.html
+func (c *Conn) RegisterPercolate(index string, id string, data interface{}) (BaseResponse, error) {
 	var url string
 	var retval BaseResponse
-	url = fmt.Sprintf("/_percolator/%s/%s", index, name)
-	body, err := c.DoCommand("PUT", url, args, query)
+	url = fmt.Sprintf("/%s/.percolator/%s", index, id)
+	body, err := c.DoCommand("PUT", url, nil, data)
 	if err != nil {
 		return retval, err
 	}

--- a/lib/corepercolate.go
+++ b/lib/corepercolate.go
@@ -16,6 +16,19 @@ import (
 	"fmt"
 )
 
+//{"took":9,"_shards":{"total":3,"successful":3,"failed":0},"total":3,
+//"matches":[{"_index":"test-geoevents-20150706-115234","_id":"nyc,West Village"},{"_index":"test-geoevents-20150706-115234","_id":"nyc,Manhattan"},{"_index":"test-geoevents-20150706-115234","_id":"nyc,Greenwich Village"}]}
+
+type PercolatorResult struct {
+	SearchResult
+	Matches []PercolatorMatch `json:"matches"`
+}
+
+type PercolatorMatch struct {
+	Index string `json:"_index"`
+	Id    string `json:"_id"`
+}
+
 // RegisterPercolate allows the caller to register queries against an index,
 // and then send percolate requests which include a doc, and getting back the
 // queries that match on that doc out of the set of registered queries.  Think
@@ -42,9 +55,9 @@ func (c *Conn) RegisterPercolate(index string, name string, args map[string]inte
 	return retval, err
 }
 
-func (c *Conn) Percolate(index string, _type string, name string, args map[string]interface{}, doc string) (Match, error) {
+func (c *Conn) Percolate(index string, _type string, name string, args map[string]interface{}, doc string) (PercolatorResult, error) {
 	var url string
-	var retval Match
+	var retval PercolatorResult
 	url = fmt.Sprintf("/%s/%s/_percolate", index, _type)
 	body, err := c.DoCommand("GET", url, args, doc)
 	if err != nil {

--- a/lib/corepercolate_test.go
+++ b/lib/corepercolate_test.go
@@ -1,0 +1,64 @@
+package elastigo
+
+import (
+	. "github.com/smartystreets/goconvey/convey"
+	"testing"
+)
+
+const (
+	percIndexName = "test-perc-index"
+)
+
+func TestPercolate(t *testing.T) {
+	Convey("With a registered percolator", t, func() {
+		c := NewTestConn()
+		_, createErr := c.CreateIndex(percIndexName)
+		So(createErr, ShouldBeNil)
+		defer c.DeleteIndex(percIndexName)
+
+		options := `{
+      "percType": {
+        "properties": {
+          "message": {
+            "type": "string"
+          }
+        }
+      }
+    }`
+
+		err := c.PutMappingFromJSON(percIndexName, "percType", []byte(options))
+		So(err, ShouldBeNil)
+
+		data := `{
+      "query": {
+        "match": {
+          "message": "bonsai tree"
+        }
+      }
+    }`
+
+		_, err = c.RegisterPercolate(percIndexName, "PERCID", data)
+		So(err, ShouldBeNil)
+
+		Convey("That matches the document", func() {
+			// Should return the percolator id (registered query)
+			doc := `{"doc": { "message": "A new bonsai tree in the office" }}`
+
+			result, err := c.Percolate(percIndexName, "percType", "", nil, doc)
+			So(err, ShouldBeNil)
+			So(len(result.Matches), ShouldEqual, 1)
+			match := result.Matches[0]
+			So(match.Id, ShouldEqual, "PERCID")
+			So(match.Index, ShouldEqual, percIndexName)
+		})
+
+		Convey("That does not match the document", func() {
+			// Should NOT return the percolator id (registered query)
+			doc := `{"doc": { "message": "Barren wasteland with no matches" }}`
+
+			result, err := c.Percolate(percIndexName, "percType", "", nil, doc)
+			So(err, ShouldBeNil)
+			So(len(result.Matches), ShouldEqual, 0)
+		})
+	})
+}


### PR DESCRIPTION
Currently, the existing `Match` struct does not comply
with json returned from a percolate query.

This fixes that.

Example percolate response as of ES 1.6.0:


```json
{"took":9,"_shards":{"total":3,"successful":3,"failed":0},"total":3,
"matches":[{"_index":"test-geoevents-20150706-115234","_id":"nyc,West Village"},{"_index":"test-geoevents-20150706-115234","_id":"nyc,Manhattan"},{"_index":"test-geoevents-20150706-115234","_id":"nyc,Greenwich Village"}]}
```