### PR TITLE
Support TTL in MappingOptions

### DIFF
--- a/lib/indicesputmapping.go
+++ b/lib/indicesputmapping.go
@@ -28,6 +28,7 @@ type MappingOptions struct {
 	Routing    *RoutingOptions        `json:"_routing,omitempty"`
 	Size       *SizeOptions           `json:"_size,omitempty"`
 	Source     *SourceOptions         `json:"_source,omitempty"`
+	TTL        *TTLOptions            `json:"_ttl,omitempty"`
 	Type       *TypeOptions           `json:"_type,omitempty"`
 	Properties map[string]interface{} `json:"properties"`
 }
@@ -64,6 +65,11 @@ type SourceOptions struct {
 type TypeOptions struct {
 	Store bool   `json:"store,omitempty"`
 	Index string `json:"index,omitempty"`
+}
+
+type TTLOptions struct {
+	Enabled bool `json:"enabled"`
+	Default string `json:"default,omitempty"`
 }
 
 type IdOptions struct {

--- a/lib/indicesputmapping_test.go
+++ b/lib/indicesputmapping_test.go
@@ -99,6 +99,7 @@ func TestPutMapping(t *testing.T) {
 		Timestamp: TimestampOptions{Enabled: true},
 		Id:        IdOptions{Index: "analyzed", Path: "id"},
 		Parent:    &ParentOptions{Type: "testParent"},
+		TTL:       &TTLOptions{Enabled: true, Default: "1w"},
 		Properties: map[string]interface{}{
 			// special properties that can't be expressed as tags
 			"multi_analyze": map[string]interface{}{
@@ -114,6 +115,7 @@ func TestPutMapping(t *testing.T) {
 		Timestamp: TimestampOptions{Enabled: true},
 		Id:        IdOptions{Index: "analyzed", Path: "id"},
 		Parent:    &ParentOptions{Type: "testParent"},
+		TTL:       &TTLOptions{Enabled: true, Default: "1w"},
 		Properties: map[string]interface{}{
 			"NoJson":        map[string]string{"type": "string"},
 			"dontIndex":     map[string]string{"index": "no"},


### PR DESCRIPTION
add support for _ttl mapping field when using the MappingOptions struct to define a mapping