### PR TITLE
Improved error handling for bulk indexing to provide more information…

### DIFF
--- a/lib/baserequest.go
+++ b/lib/baserequest.go
@@ -64,10 +64,14 @@ func (c *Conn) DoCommand(method string, url string, args map[string]interface{},
 
 	httpStatusCode, body, err = req.Do(&response)
 	if err != nil {
-		return body, err
+		if httpStatusCode == -1 {
+			//connection error like *url.Error
+			return body, err
+		}
+		//error reading response body, or something else after we obtained an HTTP status code
+		return body, ESError{time.Now(), fmt.Sprintf("Error [%v] Status [%v]", err, httpStatusCode), httpStatusCode}
 	}
 	if httpStatusCode > 304 {
-
 		jsonErr := json.Unmarshal(body, &response)
 		if jsonErr == nil {
 			if res_err, ok := response["error"]; ok {
@@ -75,7 +79,7 @@ func (c *Conn) DoCommand(method string, url string, args map[string]interface{},
 				return body, ESError{time.Now(), fmt.Sprintf("Error [%s] Status [%v]", res_err, status), httpStatusCode}
 			}
 		}
-		return body, jsonErr
+		return body, ESError{time.Now(), fmt.Sprintf("Error [%v] Status [%v]", jsonErr, httpStatusCode), httpStatusCode}
 	}
 	return body, nil
 }

--- a/lib/corebulk_test.go
+++ b/lib/corebulk_test.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/araddon/gou"
 	"github.com/bmizerany/assert"
+	"strings"
 )
 
 //  go test -bench=".*"
@@ -91,6 +92,7 @@ func TestBulkIndexerBasic(t *testing.T) {
 	<-time.After(time.Millisecond * 10) // we need to wait for doc to hit send channel
 	// this will test to ensure that Flush actually catches a doc
 	indexer.Flush()
+	<-time.After(time.Millisecond * 1) // we need to wait for the httpSender to read from the send buffer
 	totalBytesSent = totalBytesSent - len(*eshost)
 	assert.T(t, err == nil, fmt.Sprintf("Should have nil error  =%v", err))
 	assert.T(t, len(buffers) == 2, fmt.Sprintf("Should have another buffer ct=%d", len(buffers)))
@@ -100,6 +102,79 @@ func TestBulkIndexerBasic(t *testing.T) {
 	assert.T(t, closeInt(totalBytesSent, expectedBytes), fmt.Sprintf("Should have sent %v bytes but was %v", expectedBytes, totalBytesSent))
 
 	indexer.Stop()
+}
+
+func TestBulkIndexerErrors(t *testing.T){
+	testIndex := "users"
+	InitTests(true)
+	c := NewTestConn()
+
+	c.DeleteIndex(testIndex)
+
+	sent := make(chan struct{}, 1)
+
+	indexer := c.NewBulkIndexer(3)
+	indexer.Start()
+	indexer.Sender = func(buf *bytes.Buffer) error {
+		// log.Printf("buffer:%s", string(buf.Bytes()))
+		ret := indexer.Send(buf)
+		sent<-struct{}{}
+		return ret
+	}
+	errch := make(chan *ErrorBuffer, 1)
+	indexer.ErrorChannel = errch
+
+	date := time.Unix(1257894000, 0)
+
+	data := map[string]interface{}{
+		"name": "smurfettes",
+		"age": 21,
+		"date": "today",
+	}
+	data2 := map[string]interface{}{
+		"name": "smurfs",
+		"age":  "this is not an int",
+		"date": "yesterday",
+	}
+
+	_, err := c.DoCommand("PUT", fmt.Sprintf("/%s", testIndex), nil,
+	`{
+	  "mappings": {
+		"user": {
+		  "properties": {
+			"age": { "type": "integer" }
+		  }
+		}
+	  }
+	}`)
+	assert.T(t, err == nil, fmt.Sprintf("Should not return an error: %v", err))
+
+	//act
+	err = indexer.Index(testIndex, "user", "1", "", &date, data, true)
+	err2 := indexer.Index(testIndex, "user", "2", "", &date, data2, true)
+
+	<-sent
+	//assert
+	assert.T(t, err == nil, fmt.Sprintf("Should not return an error: %v", err))
+	assert.T(t, err2 == nil, fmt.Sprintf("Should not return an error: %v", err2))
+	time.Sleep(1 * time.Microsecond)
+	assert.T(t, indexer.NumErrors() == 1, fmt.Sprintf("Should have recorded 1 error but saw: %d", indexer.NumErrors()))
+
+	errBuf := <- errch
+	bulkErr, ok := errBuf.Err.(BulkIndexingError)
+	assert.T(t, ok, fmt.Sprintf("Error should have been a BulkIndexingError but was %T", errBuf.Err))
+
+	assert.T(t, len(bulkErr.Items) == 2, fmt.Sprintf("Expected 2 items in response but got: %d", len(bulkErr.Items)))
+	status1 := int(bulkErr.Items[1]["index"].(map[string]interface{})["status"].(float64))
+	assert.T(t, status1 == 400, fmt.Sprintf("Expected second item to have status 400 but was %d", status1))
+	status0 := int(bulkErr.Items[0]["index"].(map[string]interface{})["status"].(float64))
+	assert.T(t, status0 == 201, fmt.Sprintf("Expected first item to have status 201 but was %d", status0))
+
+	lines := strings.Split(errBuf.Buf.String(), "\n")
+	assert.T(t, lines[0] == `{"index":{"_index":"users","_type":"user","_id":"1","_timestamp":"1257894000000","refresh":true}}`, fmt.Sprintf("Expected index header but got: %s", lines[0]))
+	assert.T(t, lines[1] == `{"age":21,"date":"today","name":"smurfettes"}`, fmt.Sprintf("Expected document but got: %s", lines[1]))
+	assert.T(t, lines[2] == `{"index":{"_index":"users","_type":"user","_id":"2","_timestamp":"1257894000000","refresh":true}}`, fmt.Sprintf("Expected index header but got: %s", lines[2]))
+	assert.T(t, lines[3] == `{"age":"this is not an int","date":"yesterday","name":"smurfs"}`, fmt.Sprintf("Expected document but got: %s", lines[3]))
 }
 
 // currently broken in drone.io

--- a/lib/request.go
+++ b/lib/request.go
@@ -68,8 +68,8 @@ func (r *Request) SetBody(body io.Reader) {
 
 func (r *Request) Do(v interface{}) (int, []byte, error) {
 	response, bodyBytes, err := r.DoResponse(v)
-	if err != nil {
-		return -1, nil, err
+	if response == nil {
+		return -1, bodyBytes, err
 	}
 	return response.StatusCode, bodyBytes, err
 }
@@ -91,18 +91,15 @@ func (r *Request) DoResponse(v interface{}) (*http.Response, []byte, error) {
 	bodyBytes, err := ioutil.ReadAll(res.Body)
 
 	if err != nil {
-		return nil, nil, err
+		return res, nil, err
 	}
 
 	if res.StatusCode == 404 {
-		return nil, bodyBytes, RecordNotFound
+		return res, bodyBytes, RecordNotFound
 	}
 
 	if res.StatusCode > 304 && v != nil {
-		jsonErr := json.Unmarshal(bodyBytes, v)
-		if jsonErr != nil {
-			return nil, nil, jsonErr
-		}
+		err = json.Unmarshal(bodyBytes, v)
 	}
 	return res, bodyBytes, err
 }


### PR DESCRIPTION
I've been trying to use the bulk indexer in an app we're writing, and we're finding that we need to be more intelligent about error handling.  For instance, in our setup we point the app at a load balancer which redirects to our Elasticsearch nodes.  If all nodes are down we get a 503 with some html, and the elastigo library returns this as a json parsing error.

I've put in some improvements for better error handling, and a unit test which more closely demonstrates our need.