### PR TITLE
bulk api is not consistent with api doc

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -375,7 +375,7 @@ func WriteBulkBytes(op string, index string, _type string, id, ttl string, date 
 	}
 
 	if op == "update" {
-		buf.WriteString(`,"retry_on_conflict":3`)
+		buf.WriteString(`,"_retry_on_conflict":3`)
 	}
 
 	if len(ttl) > 0 {


### PR DESCRIPTION
According to the doc from [here](https://www.elastic.co/guide/en/elasticsearch/reference/current/docs-bulk.html),  `retry_on_conflict` can't be use anymore, once use it, `elasticsearch 1.7.1` will raise a error follows, and change `retry_on_conflict` to `_retry_on_conflict ` can fix it.
```
bulkIndexer: &{2015-08-24 17:54:24.32818233 +0800 CST: Error [IllegalArgumentException[Action/metadata line [1] contains an unknown parameter [retry_on_conflict]]] Status [500] [500] }
```
