### PR TITLE
remove refresh from action/meta. fixes #215

### DIFF
--- a/lib/corebulk_test.go
+++ b/lib/corebulk_test.go
@@ -17,13 +17,14 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
-	"github.com/araddon/gou"
-	"github.com/bmizerany/assert"
 	"log"
 	"net/url"
 	"strconv"
 	"testing"
 	"time"
+
+	"github.com/araddon/gou"
+	"github.com/bmizerany/assert"
 )
 
 //  go test -bench=".*"

--- a/lib/corebulk_test.go
+++ b/lib/corebulk_test.go
@@ -63,7 +63,7 @@ func TestBulkIndexerBasic(t *testing.T) {
 		messageSets += 1
 		totalBytesSent += buf.Len()
 		buffers = append(buffers, buf)
-		// log.Printf("buffer:%s", string(buf.Bytes()))
+		//log.Printf("buffer:%s", string(buf.Bytes()))
 		return indexer.Send(buf)
 	}
 	indexer.Start()
@@ -75,7 +75,7 @@ func TestBulkIndexerBasic(t *testing.T) {
 		"date": "yesterday",
 	}
 
-	err := indexer.Index(testIndex, "user", "1", "", "", &date, data, true)
+	err := indexer.Index(testIndex, "user", "1", "", "", &date, data)
 	waitFor(func() bool {
 		return len(buffers) > 0
 	}, 5)
@@ -84,10 +84,10 @@ func TestBulkIndexerBasic(t *testing.T) {
 	//totalBytesSent = totalBytesSent - len(*eshost)
 	assert.T(t, len(buffers) == 1, fmt.Sprintf("Should have sent one operation but was %d", len(buffers)))
 	assert.T(t, indexer.NumErrors() == 0 && err == nil, fmt.Sprintf("Should not have any errors. NumErrors: %v, err: %v", indexer.NumErrors(), err))
-	expectedBytes := 144
+	expectedBytes := 129
 	assert.T(t, totalBytesSent == expectedBytes, fmt.Sprintf("Should have sent %v bytes but was %v", expectedBytes, totalBytesSent))
 
-	err = indexer.Index(testIndex, "user", "2", "", "", nil, data, true)
+	err = indexer.Index(testIndex, "user", "2", "", "", nil, data)
 	waitFor(func() bool {
 		return len(buffers) > 1
 	}, 5)
@@ -99,7 +99,7 @@ func TestBulkIndexerBasic(t *testing.T) {
 	assert.T(t, len(buffers) == 2, fmt.Sprintf("Should have another buffer ct=%d", len(buffers)))
 
 	assert.T(t, indexer.NumErrors() == 0, fmt.Sprintf("Should not have any errors %d", indexer.NumErrors()))
-	expectedBytes = 250 // with refresh
+	expectedBytes = 220
 	assert.T(t, closeInt(totalBytesSent, expectedBytes), fmt.Sprintf("Should have sent %v bytes but was %v", expectedBytes, totalBytesSent))
 
 	indexer.Stop()
@@ -137,7 +137,7 @@ func XXXTestBulkUpdate(t *testing.T) {
 	data := map[string]interface{}{
 		"script": "ctx._source.count += 2",
 	}
-	err = indexer.Update("users", "user", "5", "", "", &date, data, true)
+	err = indexer.Update("users", "user", "5", "", "", &date, data)
 	// So here's the deal. Flushing does seem to work, you just have to give the
 	// channel a moment to recieve the message ...
 	//	<- time.After(time.Millisecond * 20)
@@ -183,9 +183,9 @@ func TestBulkSmallBatch(t *testing.T) {
 	indexer.Start()
 	<-time.After(time.Millisecond * 20)
 
-	indexer.Index("users", "user", "2", "", "", &date, data, true)
-	indexer.Index("users", "user", "3", "", "", &date, data, true)
-	indexer.Index("users", "user", "4", "", "", &date, data, true)
+	indexer.Index("users", "user", "2", "", "", &date, data)
+	indexer.Index("users", "user", "3", "", "", &date, data)
+	indexer.Index("users", "user", "4", "", "", &date, data)
 	<-time.After(time.Millisecond * 200)
 	//	indexer.Flush()
 	indexer.Stop()
@@ -207,14 +207,14 @@ func TestBulkDelete(t *testing.T) {
 
 	indexer.Start()
 
-	indexer.Delete("fake", "fake_type", "1", true)
+	indexer.Delete("fake", "fake_type", "1")
 
 	indexer.Flush()
 	indexer.Stop()
 
 	sent := string(sentBytes)
 
-	expected := `{"delete":{"_index":"fake","_type":"fake_type","_id":"1","refresh":true}}
+	expected := `{"delete":{"_index":"fake","_type":"fake_type","_id":"1"}}
 `
 	asExpected := sent == expected
 	assert.T(t, asExpected, fmt.Sprintf("Should have sent '%s' but actually sent '%s'", expected, sent))
@@ -234,7 +234,7 @@ func XXXTestBulkErrors(t *testing.T) {
 		for i := 0; i < 20; i++ {
 			date := time.Unix(1257894000, 0)
 			data := map[string]interface{}{"name": "smurfs", "age": 22, "date": date}
-			indexer.Index("users", "user", strconv.Itoa(i), "", "", &date, data, true)
+			indexer.Index("users", "user", strconv.Itoa(i), "", "", &date, data)
 		}
 	}()
 	var errBuf *ErrorBuffer
@@ -274,7 +274,7 @@ func BenchmarkSend(b *testing.B) {
 		about := make([]byte, 1000)
 		rand.Read(about)
 		data := map[string]interface{}{"name": "smurfs", "age": 22, "date": time.Unix(1257894000, 0), "about": about}
-		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, data, true)
+		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, data)
 	}
 	log.Printf("Sent %d messages in %d sets totaling %d bytes \n", b.N, sets, totalBytes)
 	if indexer.NumErrors() != 0 {
@@ -308,7 +308,7 @@ func BenchmarkSendBytes(b *testing.B) {
 		return indexer.Send(buf)
 	}
 	for i := 0; i < b.N; i++ {
-		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, body, true)
+		indexer.Index("users", "user", strconv.Itoa(i), "", "", nil, body)
 	}
 	log.Printf("Sent %d messages in %d sets totaling %d bytes \n", b.N, sets, totalBytes)
 	if indexer.NumErrors() != 0 {

--- a/lib/coreexample_test.go
+++ b/lib/coreexample_test.go
@@ -25,7 +25,7 @@ func ExampleBulkIndexer_simple() {
 
 	indexer := c.NewBulkIndexerErrors(10, 60)
 	indexer.Start()
-	indexer.Index("twitter", "user", "1", "", "", nil, `{"name":"bob"}`, true)
+	indexer.Index("twitter", "user", "1", "", "", nil, `{"name":"bob"}`)
 	indexer.Stop()
 }
 
@@ -46,7 +46,7 @@ func ExampleBulkIndexer_responses() {
 	}
 	indexer.Start()
 	for i := 0; i < 20; i++ {
-		indexer.Index("twitter", "user", strconv.Itoa(i), "", "", nil, `{"name":"bob"}`, true)
+		indexer.Index("twitter", "user", strconv.Itoa(i), "", "", nil, `{"name":"bob"}`)
 	}
 	indexer.Stop()
 }

--- a/lib/coretest_test.go
+++ b/lib/coretest_test.go
@@ -179,7 +179,7 @@ func LoadTestData() {
 				log.Println("HM, already exists? ", ge.Url)
 			}
 			docsm[id] = true
-			indexer.Index(testIndex, ge.Type, id, "", "", &ge.Created, line, true)
+			indexer.Index(testIndex, ge.Type, id, "", "", &ge.Created, line)
 			docCt++
 		} else {
 			log.Println("ERROR? ", string(line))


### PR DESCRIPTION
This commit moves the refresh property to be
an attribute of the BulkIndexer struct.
The refresh attribute is included as a query param
when the request is sent to the Elasticsearch API.