### PR TITLE
Fixed Escape to handle int32, int64, and float32

### DIFF
--- a/lib/request.go
+++ b/lib/request.go
@@ -15,13 +15,15 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	hostpool "github.com/bitly/go-hostpool"
 	"io"
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"reflect"
 	"strconv"
 	"strings"
+
+	hostpool "github.com/bitly/go-hostpool"
 )
 
 type Request struct {
@@ -107,9 +109,11 @@ func Escape(args map[string]interface{}) (s string, err error) {
 		case bool:
 			vals.Add(key, strconv.FormatBool(v))
 		case int, int32, int64:
-			vals.Add(key, strconv.Itoa(v.(int)))
+			vInt := reflect.ValueOf(v).Int()
+			vals.Add(key, strconv.FormatInt(vInt, 10))
 		case float32, float64:
-			vals.Add(key, strconv.FormatFloat(v.(float64), 'f', -1, 64))
+			vFloat := reflect.ValueOf(v).Float()
+			vals.Add(key, strconv.FormatFloat(vFloat, 'f', -1, 32))
 		case []string:
 			vals.Add(key, strings.Join(v, ","))
 		default:

--- a/lib/request_test.go
+++ b/lib/request_test.go
@@ -37,7 +37,7 @@ func TestQueryString(t *testing.T) {
 	exp = "foo=1"
 	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
 
-	// Test single int64 argument
+	// Test single int32 argument
 	s, err = Escape(map[string]interface{}{"foo": int32(1)})
 	exp = "foo=1"
 	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
@@ -47,6 +47,7 @@ func TestQueryString(t *testing.T) {
 	exp = "foo=3.141592"
 	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
 
+	// Test single float32 argument
 	s, err = Escape(map[string]interface{}{"foo": float32(3.141592)})
 	exp = "foo=3.141592"
 	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))

--- a/lib/request_test.go
+++ b/lib/request_test.go
@@ -28,12 +28,26 @@ func TestQueryString(t *testing.T) {
 	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
 
 	// Test single int argument
-	s, err = Escape(map[string]interface{}{"foo": 1})
+	s, err = Escape(map[string]interface{}{"foo": int(1)})
 	exp = "foo=1"
 	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
 
-	// Test single float argument
-	s, err = Escape(map[string]interface{}{"foo": 3.141592})
+	// Test single int64 argument
+	s, err = Escape(map[string]interface{}{"foo": int64(1)})
+	exp = "foo=1"
+	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
+
+	// Test single int64 argument
+	s, err = Escape(map[string]interface{}{"foo": int32(1)})
+	exp = "foo=1"
+	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
+
+	// Test single float64 argument
+	s, err = Escape(map[string]interface{}{"foo": float64(3.141592)})
+	exp = "foo=3.141592"
+	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
+
+	s, err = Escape(map[string]interface{}{"foo": float32(3.141592)})
 	exp = "foo=3.141592"
 	assert.T(t, s == exp && err == nil, fmt.Sprintf("Expected %s, got: %s", exp, s))
 


### PR DESCRIPTION
The current implementation of Escape fails for many of the types in the type switch. This change allows all types of ints and floats to be used.

Tests are added to check against these conditions.
This fixes passes the tests using `go test *.go -test.run=TestQuery`