### PR TITLE
Explicitly stop ticker to avoid memory leaks

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -237,6 +237,7 @@ func (b *BulkIndexer) startTimer() {
 				b.mu.Unlock()
 			case <-b.timerDoneChan:
 				// shutdown this go routine
+				ticker.Stop()
 				return
 			}
 


### PR DESCRIPTION
This patch ensures the ticker gets stopped when shutdown is called on a BulkIndexer to prevent memory leaks.