### PR TITLE
Send an unread Buffer to the ErrorChannel

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -193,6 +193,7 @@ func (b *BulkIndexer) startHttpSender() {
 				//  2.  Retry then return error and let runner decide
 				//  3.  Retry, then log to disk?   retry later?
 				if err != nil {
+					buf = bytes.NewBuffer(bufCopy.Bytes())
 					if b.RetryForSeconds > 0 {
 						time.Sleep(time.Second * time.Duration(b.RetryForSeconds))
 						err = b.Sender(bufCopy)


### PR DESCRIPTION
If the message buffer has been read, the buffer sent through the ErrorChannel will be empty. This pull request copies the buffer back from the bufCopy used for retries.