### PR TITLE
Parse `sort` field in search results

### DIFF
--- a/lib/coresearch.go
+++ b/lib/coresearch.go
@@ -209,6 +209,7 @@ type Hit struct {
 	Fields      *json.RawMessage `json:"fields"`           // when a field arg is passed to ES, instead of _source it returns fields
 	Explanation *Explanation     `json:"_explanation,omitempty"`
 	Highlight   *Highlight       `json:"highlight,omitempty"`
+	Sort        []interface{}    `json:"sort,omitempty"`
 }
 
 func (e *Explanation) String(indent string) string {


### PR DESCRIPTION
If `sort` field is present in the search request, Elastic will add the sort value for each hit record.
https://www.elastic.co/guide/en/elasticsearch/guide/current/_sorting.html

These values should be parsed in order to avoid parsing response twice to get them.