### PR TITLE
Add Sanitize for query input sanitization

### DIFF
--- a/lib/sanitize.go
+++ b/lib/sanitize.go
@@ -1,0 +1,32 @@
+// Copyright 2013 Matthew Baird, Dimitri Roche
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//     http://www.apache.org/licenses/LICENSE-2.0
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package elastigo
+
+import (
+	"regexp"
+	"strings"
+)
+
+// Sanitize Elastic Search query string input.
+// Inspired by https://github.com/lanetix/node-elasticsearch-sanitize
+// Removed escaping of white space because Elasticsearch complained
+func Sanitize(input string) string {
+	charReg := regexp.MustCompile("[\\*\\+\\-=~><\"\\?^\\${}\\(\\)\\:\\!\\/[\\]]+")
+
+	output := charReg.ReplaceAllString(input, "\\$0")
+	output = strings.Replace(output, "||", "\\||", -1)
+	output = strings.Replace(output, "&&", "\\&&", -1)
+	output = strings.Replace(output, "AND", "\\A\\N\\D", -1)
+	output = strings.Replace(output, "OR", "\\O\\R", -1)
+	output = strings.Replace(output, "NOT", "\\N\\O\\T", -1)
+	return output
+}

--- a/lib/sanitize_test.go
+++ b/lib/sanitize_test.go
@@ -1,0 +1,14 @@
+package elastigo
+
+import (
+	"github.com/bmizerany/assert"
+	"testing"
+)
+
+func TestSanitizeReferenceSentence(t *testing.T) {
+	input := "AND there! are? (lots of) char*cters 2 ^escape!"
+	expectation := `\A\N\D there\! are\? \(lots of\) char\*cters 2 \^escape\!`
+
+	actual := Sanitize(input)
+	assert.Equal(t, expectation, actual)
+}


### PR DESCRIPTION
Useful when passing through search queries from search form that's available to an end user.

Referenced this node implementation:
https://github.com/lanetix/node-elasticsearch-sanitize