### PR TITLE
Fix PendingDocuments function datarace

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -162,6 +162,8 @@ func (b *BulkIndexer) Stop() {
 }
 
 func (b *BulkIndexer) PendingDocuments() int {
+	b.mu.Lock()
+	defer b.mu.Unlock()
 	return b.docCt
 }
 


### PR DESCRIPTION
When using `PendingDocuments()`, sometimes occurred data race issue.
So I have fixed that.