### PR TITLE
Adds source filtering for SearchDsl

### DIFF
--- a/lib/searchsearch.go
+++ b/lib/searchsearch.go
@@ -124,6 +124,10 @@ func (s *SearchDsl) Source(returnSource bool) *SearchDsl {
 	return s
 }
 
+func (s *SearchDsl) SourceFields(fields ...string) *SearchDsl {
+	s.args["_source"] = fields
+	return s
+}
 // Facet passes a Query expression to this search
 //
 //		qry := Search("github").Size("0").Facet(

--- a/lib/searchsearch_test.go
+++ b/lib/searchsearch_test.go
@@ -288,4 +288,21 @@ func TestSearch(t *testing.T) {
 		h1 := gou.NewJsonHelper(b)
 		So(h1.String("name"), ShouldEqual, "Wayne Gretzky")
 	})
+
+	Convey("Search query with filtered source fields", t, func() {
+
+		qry := Search("oilers").SourceFields("name", "goals").Pretty().Query(
+			Query().All(),
+		)
+		out, err := qry.Result(c)
+
+		So(err, ShouldBeNil)
+		So(out, ShouldNotBeNil)
+		So(out.Hits.Len(), ShouldEqual, 10)
+		So(out.Hits.Total, ShouldEqual, 14)
+
+		b, err := out.Hits.Hits[0].Source.MarshalJSON()
+		h1 := gou.NewJsonHelper(b)
+		So(h1.Keys(), ShouldResemble, []string{"name", "goals"})
+	})
 }


### PR DESCRIPTION
This is different from the Fields methods as ElasticSearch will return a _source with only the fields specified.

It is a quick attempt to fix my needs. If I miss something, just tell me what I should change and I will =)
Also, I didn't add tests as the normal Source method doesn't have one.

Thanks for the lib.