### PR TITLE
Update baseresponse.go

### DIFF
--- a/lib/baseresponse.go
+++ b/lib/baseresponse.go
@@ -94,7 +94,7 @@ type Status struct {
 type Failure struct {
 	Index  string    `json:"index"`
 	Shard  StatusInt `json:"shard"`
-	Reason string    `json:"reason"`
+	Reason json.RawMessage    `json:"reason"`
 }
 
 func (f Failure) String() string {


### PR DESCRIPTION
Hello, when I use elastigo found inside the package is the core of search methods. When the result of elasticsearch returned and the reason is that this field appears when the field is not a string type, will json Unmarshal error occurs, I will reason the string replaced json.RawMessage, solves this problem.