### PR TITLE
Bring back MaxScore by using Float32Nullable

### DIFF
--- a/lib/coresearch.go
+++ b/lib/coresearch.go
@@ -189,9 +189,9 @@ func (s *SearchResult) String() string {
 }
 
 type Hits struct {
-	Total int `json:"total"`
-	//	MaxScore float32 `json:"max_score"`
-	Hits []Hit `json:"hits"`
+	Total    int             `json:"total"`
+	MaxScore Float32Nullable `json:"max_score"`
+	Hits     []Hit           `json:"hits"`
 }
 
 func (h *Hits) Len() int {


### PR DESCRIPTION
Make `MaxScore` `Float32Nullable` so that we can uncomment it in Hits. It was originally commented in e7e1c02 by @mschoch because Float32Nullable didn't exist at the time.