### PR TITLE
I use elasticsearch version 2.1.0 ,when get all nodes info return val…

### DIFF
--- a/lib/clusternodesinfo.go
+++ b/lib/clusternodesinfo.go
@@ -166,13 +166,13 @@ type Interface struct {
 }
 
 type Transport struct {
-	BoundAddress   string `json:"bound_address,omitempty"`
-	PublishAddress string `json:"publish_address,omitempty"`
+	BoundAddress   []string `json:"bound_address,omitempty"`
+	PublishAddress string   `json:"publish_address,omitempty"`
 }
 
 type Http struct {
-	BoundAddress   string `json:"bound_address,omitempty"`
-	PublishAddress string `json:"publish_address,omitempty"`
+	BoundAddress   []string `json:"bound_address,omitempty"`
+	PublishAddress string   `json:"publish_address,omitempty"`
 }
 
 type Plugin struct {


### PR DESCRIPTION
…ue Transport.BoundAddress and Http.BoundAddress are array not string now.
