### PR TITLE
handle ES5.1.1 json index info

### DIFF
--- a/lib/catresponses.go
+++ b/lib/catresponses.go
@@ -1,18 +1,30 @@
 package elastigo
 
 type CatIndexInfo struct {
-	Health   string
-	Status   string
-	Name     string
-	Shards   int
-	Replicas int
-	Docs     CatIndexDocs
-	Store    CatIndexStore
+	Health   string        `json:"health"`
+	Status   string        `json:"status"`
+	Name     string        `json:"index"`
+	Shards   int           `json:"pri"`
+	Replicas int           `json:"rep"`
+	Docs     CatIndexDocs  `json:"docs"`
+	Store    CatIndexStore `json:"store"`
+}
+
+type CatIndexInfoEs5 struct {
+	Health       string `json:"health"`
+	Status       string `json:"status"`
+	Name         string `json:"index"`
+	Shards       string `json:"pri"`
+	Replicas     string `json:"rep"`
+	DocsCount    string `json:"docs.count"`
+	DocsDel      string `json:"docs.deleted"`
+	StoreSize    string `json:"store.size"`
+	PriStoreSize string `json:"pri.store.size"`
 }
 
 type CatIndexDocs struct {
-	Count   int64
-	Deleted int64
+	Count   int64 `json:"count"`
+	Deleted int64 `json:"deleted"`
 }
 
 type CatIndexStore struct {


### PR DESCRIPTION
ElasticSearch 5.1.1 returns index info in a JSON struct,
rather than a newline delimited set of fields, in response
to the query in Conn.GetCatIndexInfo().

Add GetCatIndexInfoEs5(), which parses the JSON,
to handle this situation.