### PR TITLE
add parent and routing options for bulk operations

### DIFF
--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -352,7 +352,12 @@ func (b *BulkIndexer) Send(buf *bytes.Buffer) error {
 	if jsonErr == nil {
 		if response.Errors {
 			atomic.AddUint64(&b.numErrors, uint64(len(response.Items)))
-			return fmt.Errorf("Bulk Insertion Error. Failed item count [%d]", len(response.Items))
+			itemJson, err := json.Marshal(response.Items)
+			if err == nil {
+				return fmt.Errorf("Bulk Insertion Error. Failed item count [%d]. Response Items: %s", len(response.Items), itemJson)
+			} else {
+				return fmt.Errorf("Bulk Insertion Error. Failed item count [%d]. Error marshalling response items: %s", len(response.Items), err)
+			}
 		}
 	}
 	return nil

--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -278,9 +278,9 @@ func (b *BulkIndexer) shutdown() {
 // The index bulk API adds or updates a typed JSON document to a specific index, making it searchable.
 // it operates by buffering requests, and ocassionally flushing to elasticsearch
 // http://www.elasticsearch.org/guide/reference/api/bulk.html
-func (b *BulkIndexer) Index(index string, _type string, id, parent, ttl string, date *time.Time, data interface{}) error {
+func (b *BulkIndexer) Index(index string, _type string, id, parent, routing, ttl string, date *time.Time, data interface{}) error {
 	//{ "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
-	by, err := WriteBulkBytes("index", index, _type, id, parent, ttl, date, data)
+	by, err := WriteBulkBytes("index", index, _type, id, parent, routing, ttl, date, data)
 	if err != nil {
 		return err
 	}
@@ -288,9 +288,9 @@ func (b *BulkIndexer) Index(index string, _type string, id, parent, ttl string, 
 	return nil
 }
 
-func (b *BulkIndexer) Update(index string, _type string, id, parent, ttl string, date *time.Time, data interface{}) error {
+func (b *BulkIndexer) Update(index string, _type string, id, parent, routing, ttl string, date *time.Time, data interface{}) error {
 	//{ "index" : { "_index" : "test", "_type" : "type1", "_id" : "1" } }
-	by, err := WriteBulkBytes("update", index, _type, id, parent, ttl, date, data)
+	by, err := WriteBulkBytes("update", index, _type, id, parent, routing, ttl, date, data)
 	if err != nil {
 		return err
 	}
@@ -298,20 +298,28 @@ func (b *BulkIndexer) Update(index string, _type string, id, parent, ttl string,
 	return nil
 }
 
-func (b *BulkIndexer) Delete(index, _type, id string) {
-	queryLine := fmt.Sprintf("{\"delete\":{\"_index\":%q,\"_type\":%q,\"_id\":%q}}\n", index, _type, id)
-	b.bulkChannel <- []byte(queryLine)
+func (b *BulkIndexer) Delete(index, _type, _parent, _routing, id string) {
+	queryLine := bytes.Buffer{}
+	queryLine.WriteString(fmt.Sprintf("{\"delete\":{\"_index\":%q,\"_type\":%q,\"_id\":%q", index, _type, id))
+	if len(_parent) > 0 {
+		queryLine.WriteString(fmt.Sprintf(",\"_parent\":%q", _parent))
+	}
+	if len(_routing) > 0 {
+		queryLine.WriteString(fmt.Sprintf(",\"_routing\":%q", _routing))
+	}
+	queryLine.WriteString("}}\n")
+	b.bulkChannel <- queryLine.Bytes()
 	return
 }
 
-func (b *BulkIndexer) UpdateWithWithScript(index string, _type string, id, parent, ttl string, date *time.Time, script string) error {
+func (b *BulkIndexer) UpdateWithWithScript(index string, _type string, id, parent, routing, ttl string, date *time.Time, script string) error {
 
 	var data map[string]interface{} = make(map[string]interface{})
 	data["script"] = script
-	return b.Update(index, _type, id, parent, ttl, date, data)
+	return b.Update(index, _type, id, parent, routing, ttl, date, data)
 }
 
-func (b *BulkIndexer) UpdateWithPartialDoc(index string, _type string, id, parent, ttl string, date *time.Time, partialDoc interface{}, upsert bool) error {
+func (b *BulkIndexer) UpdateWithPartialDoc(index string, _type string, id, parent, routing, ttl string, date *time.Time, partialDoc interface{}, upsert bool) error {
 
 	var data map[string]interface{} = make(map[string]interface{})
 
@@ -319,7 +327,7 @@ func (b *BulkIndexer) UpdateWithPartialDoc(index string, _type string, id, paren
 	if upsert {
 		data["doc_as_upsert"] = true
 	}
-	return b.Update(index, _type, id, parent, ttl, date, data)
+	return b.Update(index, _type, id, parent, routing, ttl, date, data)
 }
 
 // This does the actual send of a buffer, which has already been formatted
@@ -352,7 +360,7 @@ func (b *BulkIndexer) Send(buf *bytes.Buffer) error {
 
 // Given a set of arguments for index, type, id, data create a set of bytes that is formatted for bulkd index
 // http://www.elasticsearch.org/guide/reference/api/bulk.html
-func WriteBulkBytes(op string, index string, _type string, id, parent, ttl string, date *time.Time, data interface{}) ([]byte, error) {
+func WriteBulkBytes(op string, index string, _type string, id, parent, routing, ttl string, date *time.Time, data interface{}) ([]byte, error) {
 	// only index and update are currently supported
 	if op != "index" && op != "update" {
 		return nil, errors.New(fmt.Sprintf("Operation '%s' is not yet supported", op))
@@ -374,6 +382,12 @@ func WriteBulkBytes(op string, index string, _type string, id, parent, ttl strin
 	if len(parent) > 0 {
 		buf.WriteString(`,"_parent":"`)
 		buf.WriteString(parent)
+		buf.WriteString(`"`)
+	}
+
+	if len(routing) > 0 {
+		buf.WriteString(`,"_routing":"`)
+		buf.WriteString(routing)
 		buf.WriteString(`"`)
 	}
 

--- a/lib/corebulk.go
+++ b/lib/corebulk.go
@@ -137,6 +137,10 @@ func (b *BulkIndexer) Start() {
 		if b.Sender == nil {
 			b.Sender = b.Send
 		}
+		// Resize bulk channel buffer if max docs greater than default
+		if b.BulkMaxDocs > BulkMaxDocs {
+			b.bulkChannel = make(chan []byte, b.BulkMaxDocs)
+		}
 		// Backwards compatibility
 		b.startHttpSender()
 		b.startDocChannel()

--- a/lib/coretest_test.go
+++ b/lib/coretest_test.go
@@ -179,7 +179,7 @@ func LoadTestData() {
 				log.Println("HM, already exists? ", ge.Url)
 			}
 			docsm[id] = true
-			indexer.Index(testIndex, ge.Type, id, "", "", &ge.Created, line)
+			indexer.Index(testIndex, ge.Type, id, "", "", "", &ge.Created, line)
 			docCt++
 		} else {
 			log.Println("ERROR? ", string(line))


### PR DESCRIPTION
this PR adds the ability to specify parent and routing options during bulk indexing